### PR TITLE
[codex] add feedback attribution and flywheel analytics dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           -e DEBUG=true \
           -e PYTHONPATH=/app/backend \
           --workdir /app \
-          flywheel:test python -m pytest tests/ -q --tb=short
+          flywheel:test python -m pytest -q --tb=short
           
     - name: Test Docker Compose
       run: |

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
 
 - **Dynamic AI Model Configuration**: Switch between different OpenAI models and adjust parameters on-the-fly
 - **PostgreSQL Persistence**: Store chat history, user feedback, and configurations in a Railway-ready PostgreSQL instance (SQLite remains an optional local fallback)
+- **Feedback Attribution**: Link each rating to the exact assistant response, model, and chatbot configuration that produced it
+- **Flywheel Analytics**: Compare approval rate, feedback coverage, response volume, and latency by configuration
 - **Time Utility Endpoint**: Quickly fetch the current UTC timestamp via the lightweight `/current_time` endpoint
 - **RESTful API**: Clean, well-documented API endpoints with automatic OpenAPI documentation
 - **Error Handling & Logging**: Comprehensive error handling with structured logging
@@ -181,6 +183,17 @@ Once the application is running, visit:
 #### Feedback
 - `POST /api/v1/feedback` - Submit user feedback
 - `GET /api/v1/feedback` - Retrieve feedback entries
+
+Feedback requests can include `response_id`, the `assistant_message_id` returned
+by the chat endpoint. The backend derives the associated configuration
+automatically.
+
+#### Flywheel Analytics
+- `GET /api/v1/analytics/configurations` - Configuration-level response and feedback metrics
+- `GET /api/v1/analytics/negative-feedback` - Recent negative examples with prompt, response, model, and configuration
+
+Analytics endpoints require `Authorization: Bearer <APP_TOKEN>` when
+`APP_TOKEN` is configured.
 
 #### Health
 - `GET /` - API status and version

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
 - **PostgreSQL Persistence**: Store chat history, user feedback, and configurations in a Railway-ready PostgreSQL instance (SQLite remains an optional local fallback)
 - **Feedback Attribution**: Link each rating to the exact assistant response, model, and chatbot configuration that produced it
 - **Flywheel Analytics**: Compare approval rate, feedback coverage, response volume, and latency by configuration
+- **Internal Dashboard**: Review configuration metrics and negative feedback examples directly in the web interface
 - **Time Utility Endpoint**: Quickly fetch the current UTC timestamp via the lightweight `/current_time` endpoint
 - **RESTful API**: Clean, well-documented API endpoints with automatic OpenAPI documentation
 - **Error Handling & Logging**: Comprehensive error handling with structured logging
@@ -194,6 +195,10 @@ automatically.
 
 Analytics endpoints require `Authorization: Bearer <APP_TOKEN>` when
 `APP_TOKEN` is configured.
+
+Open the application and select **Flywheel Analytics** in the sidebar to view
+the dashboard. If production analytics are protected, enter `APP_TOKEN`; it is
+kept in browser session storage and cleared when the browser session ends.
 
 #### Health
 - `GET /` - API status and version

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -6,10 +6,13 @@ Provides centralized bearer token verification for protected endpoints.
 from fastapi import Depends, HTTPException, Security
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 import os
+from typing import Optional
 
-security = HTTPBearer()
+security = HTTPBearer(auto_error=False)
 
-def verify_bearer_token(credentials: HTTPAuthorizationCredentials = Security(security)):
+def verify_bearer_token(
+    credentials: Optional[HTTPAuthorizationCredentials] = Security(security),
+):
     """
     Verify bearer token for protected endpoints.
     

--- a/backend/app/init_db.py
+++ b/backend/app/init_db.py
@@ -28,6 +28,15 @@ def apply_migrations(db_path: str) -> None:
         raise
 
 
+def apply_attribution_migration() -> None:
+    """Add flywheel attribution columns on supported database backends."""
+    from .migrations.add_flywheel_attribution import run_migration
+
+    applied = run_migration(engine)
+    if applied:
+        logger.info(f"Applied attribution migrations: {', '.join(applied)}")
+
+
 def init_database() -> None:
     """
     Initialize the database by creating all tables.
@@ -54,6 +63,8 @@ def init_database() -> None:
             apply_migrations(db_path)
         else:
             logger.info("Skipping SQLite-specific migrations for non-SQLite backend.")
+
+        apply_attribution_migration()
 
         from sqlalchemy import inspect
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,6 +21,7 @@ from .utils import setup_logging, format_error_response
 from .routes import router
 from .routes_configs import router as configs_router
 from .routes_knowledge import router as knowledge_router
+from .routes_analytics import router as analytics_router
 from .demo_seed import seed_demo
 from .init_db import init_database
 
@@ -127,6 +128,7 @@ def current_time():
 app.include_router(router, prefix="/api/v1")
 app.include_router(configs_router, prefix="/api/v1")
 app.include_router(knowledge_router, prefix="/api/v1")
+app.include_router(analytics_router, prefix="/api/v1")
 
 # Database path logging for debugging
 try:

--- a/backend/app/migrations/add_flywheel_attribution.py
+++ b/backend/app/migrations/add_flywheel_attribution.py
@@ -1,0 +1,62 @@
+"""Add response/configuration attribution columns for the data flywheel."""
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+
+
+def _add_column(engine: Engine, table: str, name: str, definition: str) -> bool:
+    columns = {column["name"] for column in inspect(engine).get_columns(table)}
+    if name in columns:
+        return False
+
+    with engine.begin() as connection:
+        connection.execute(text(f"ALTER TABLE {table} ADD COLUMN {name} {definition}"))
+    return True
+
+
+def run_migration(engine: Engine) -> list[str]:
+    """Apply additive, backward-compatible attribution columns."""
+    inspector = inspect(engine)
+    tables = set(inspector.get_table_names())
+    applied: list[str] = []
+
+    if "chat_history" in tables:
+        chat_columns = {
+            "config_id": "INTEGER",
+            "model_name": "VARCHAR(100)",
+            "latency_ms": "INTEGER",
+        }
+        for name, definition in chat_columns.items():
+            if _add_column(engine, "chat_history", name, definition):
+                applied.append(f"chat_history.{name}")
+
+    if "feedback" in tables:
+        feedback_columns = {
+            "response_id": "INTEGER",
+            "config_id": "INTEGER",
+        }
+        for name, definition in feedback_columns.items():
+            if _add_column(engine, "feedback", name, definition):
+                applied.append(f"feedback.{name}")
+
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS "
+                "ix_chat_history_config_id ON chat_history (config_id)"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS "
+                "ix_feedback_response_id ON feedback (response_id)"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS "
+                "ix_feedback_config_id ON feedback (config_id)"
+            )
+        )
+
+    return applied

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -30,7 +30,7 @@ class Feedback(Base):
     comment = Column(Text, nullable=True, comment="Optional user comment")
     response_id = Column(
         Integer,
-        ForeignKey("chat_history.id"),
+        ForeignKey("chat_history.id", ondelete="SET NULL"),
         nullable=True,
         index=True,
         comment="Assistant response being rated",

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -28,6 +28,20 @@ class Feedback(Base):
     message = Column(Text, nullable=False, comment="Original message that was rated")
     user_feedback = Column(String(50), nullable=True, comment="User rating (thumbs_up/thumbs_down)")
     comment = Column(Text, nullable=True, comment="Optional user comment")
+    response_id = Column(
+        Integer,
+        ForeignKey("chat_history.id"),
+        nullable=True,
+        index=True,
+        comment="Assistant response being rated",
+    )
+    config_id = Column(
+        Integer,
+        ForeignKey("chatbot_config.id"),
+        nullable=True,
+        index=True,
+        comment="Configuration attributed to the rated response",
+    )
     timestamp = Column(DateTime(timezone=True), server_default=func.now(), comment="Feedback submission time")
 
     def __repr__(self) -> str:
@@ -54,6 +68,15 @@ class ChatHistory(Base):
     content = Column(Text, nullable=False, comment="Message content")
     created_at = Column(DateTime(timezone=True), server_default=func.now(), comment="Message timestamp")
     user_id = Column(String(100), nullable=True, comment="Optional user identifier")
+    config_id = Column(
+        Integer,
+        ForeignKey("chatbot_config.id"),
+        nullable=True,
+        index=True,
+        comment="Configuration used for this message",
+    )
+    model_name = Column(String(100), nullable=True, comment="Model used for assistant responses")
+    latency_ms = Column(Integer, nullable=True, comment="Assistant response latency in milliseconds")
 
     def __repr__(self) -> str:
         return f"<ChatHistory(id={self.id}, role={self.role}, session_id={self.session_id})>"

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -653,6 +653,23 @@ async def delete_session(
         Confirmation of deletion
     """
     try:
+        message_ids = [
+            message_id
+            for (message_id,) in (
+                db.query(ChatHistory.id)
+                .filter(ChatHistory.session_id == session_id)
+                .all()
+            )
+        ]
+        if message_ids:
+            (
+                db.query(Feedback)
+                .filter(Feedback.response_id.in_(message_ids))
+                .update(
+                    {Feedback.response_id: None},
+                    synchronize_session=False,
+                )
+            )
         db.query(ChatHistory).filter(ChatHistory.session_id == session_id).delete()
         db.commit()
         return {"status": "deleted", "session_id": session_id}

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -81,10 +81,30 @@ async def submit_feedback(request: FeedbackCreate, db: Session = Depends(get_db)
         sanitized_message = sanitize_user_input(request.message)
         sanitized_comment = sanitize_user_input(request.comment) if request.comment else None
 
+        response = None
+        config_id = None
+        if request.response_id is not None:
+            response = (
+                db.query(ChatHistory)
+                .filter(
+                    ChatHistory.id == request.response_id,
+                    ChatHistory.role == "assistant",
+                )
+                .first()
+            )
+            if response is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Assistant response not found",
+                )
+            config_id = response.config_id
+
         feedback = Feedback(
             message=sanitized_message,
             user_feedback=request.user_feedback,
-            comment=sanitized_comment
+            comment=sanitized_comment,
+            response_id=request.response_id,
+            config_id=config_id,
         )
 
         db.add(feedback)
@@ -94,6 +114,8 @@ async def submit_feedback(request: FeedbackCreate, db: Session = Depends(get_db)
         logger.info(f"Feedback submitted successfully with ID: {feedback.id}")
         return {"status": "success", "id": feedback.id}
 
+    except HTTPException:
+        raise
     except SQLAlchemyError as e:
         logger.error(f"Database error while submitting feedback: {str(e)}")
         db.rollback()
@@ -142,6 +164,8 @@ async def get_feedback(
                 "message": f.message,
                 "user_feedback": f.user_feedback,
                 "comment": f.comment,
+                "response_id": f.response_id,
+                "config_id": f.config_id,
                 "timestamp": f.timestamp.isoformat()
             }
             for f in feedback_entries
@@ -200,6 +224,14 @@ async def chat_with_bot(
                 detail="Message cannot be empty"
             )
 
+        local_settings = get_settings()
+        config = (
+            db.query(ChatbotConfig)
+            .filter(ChatbotConfig.is_active.is_(True))
+            .order_by(ChatbotConfig.updated_at.desc())
+            .first()
+        )
+
         lower_message = sanitized_message.lower()
         time_triggers = (
             "what time is it",
@@ -215,6 +247,7 @@ async def chat_with_bot(
                 role="user",
                 content=sanitized_message,
                 user_id=request.user_id,
+                config_id=config.id if config else None,
             )
             db.add(user_chat)
             db.commit()
@@ -227,15 +260,25 @@ async def chat_with_bot(
                 session_id=user_chat.session_id,
                 role="assistant",
                 content=reply_text,
+                config_id=config.id if config else None,
+                model_name="system-clock",
+                latency_ms=0,
             )
             db.add(assistant_chat)
             db.commit()
+            db.refresh(assistant_chat)
 
             logger.info(f"Handled time request with direct response: {current_time_iso}")
 
             if stream:
                 async def stream_time():
-                    payload = {"reply": reply_text, "session_id": user_chat.session_id}
+                    payload = {
+                        "reply": reply_text,
+                        "session_id": user_chat.session_id,
+                        "assistant_message_id": assistant_chat.id,
+                        "config_id": config.id if config else None,
+                        "model": "system-clock",
+                    }
                     yield f"data: {json.dumps(payload)}\n\n"
 
                 headers = {
@@ -249,7 +292,13 @@ async def chat_with_bot(
                     headers=headers,
                 )
 
-            return {"reply": reply_text, "session_id": user_chat.session_id}
+            return {
+                "reply": reply_text,
+                "session_id": user_chat.session_id,
+                "assistant_message_id": assistant_chat.id,
+                "config_id": config.id if config else None,
+                "model": "system-clock",
+            }
 
         # Search knowledge base for relevant information
         knowledge_processor = KnowledgeProcessor()
@@ -258,9 +307,6 @@ async def chat_with_bot(
         logger.info(f"Found {len(knowledge_snippets)} relevant knowledge snippets")
 
         # Load latest chatbot configuration
-        local_settings = get_settings()
-        config = db.query(ChatbotConfig).order_by(ChatbotConfig.updated_at.desc()).first()
-
         if config:
             base_system_prompt = config.config_json.get("system_prompt", "You are a helpful and adaptive assistant.")
             temperature = config.config_json.get("temperature", local_settings.default_temperature)
@@ -313,7 +359,8 @@ async def chat_with_bot(
             session_id=request.session_id or str(uuid.uuid4()),
             role='user',
             content=sanitized_message,
-            user_id=request.user_id
+            user_id=request.user_id,
+            config_id=config.id if config else None,
         )
         db.add(user_chat)
         db.commit()  # Commit user message before streaming to prevent data loss
@@ -323,7 +370,12 @@ async def chat_with_bot(
         if stream:
             async def generate_response():
                 full_response = ""
-                response_data = {"reply": "", "session_id": user_chat.session_id}
+                response_data = {
+                    "reply": "",
+                    "session_id": user_chat.session_id,
+                    "config_id": config.id if config else None,
+                    "model": model,
+                }
                 start_time = time.time()
                 total_tokens = 0
 
@@ -360,13 +412,19 @@ async def chat_with_bot(
                                 assistant_chat = ChatHistory(
                                     session_id=user_chat.session_id,
                                     role='assistant',
-                                    content=full_response
+                                    content=full_response,
+                                    config_id=config.id if config else None,
+                                    model_name=model,
+                                    latency_ms=int((time.time() - start_time) * 1000),
                                 )
                                 db.add(assistant_chat)
                                 db.commit()
+                                db.refresh(assistant_chat)
+                                response_data["assistant_message_id"] = assistant_chat.id
+                                yield f"data: {json.dumps(response_data)}\n\n"
 
                                 # Log streaming performance
-                                latency_ms = int((time.time() - start_time) * 1000)
+                                latency_ms = assistant_chat.latency_ms
                                 logger.info(
                                     f"Streamed chat processed. "
                                     f"Session: {user_chat.session_id}, "
@@ -408,6 +466,7 @@ async def chat_with_bot(
             )
 
         # Non-streaming response
+        start_time = time.time()
         llm_response = await chat(
             messages=messages,
             model=model,
@@ -435,13 +494,26 @@ async def chat_with_bot(
         assistant_chat = ChatHistory(
             session_id=user_chat.session_id,
             role='assistant',
-            content=reply
+            content=reply,
+            config_id=config.id if config else None,
+            model_name=model,
+            latency_ms=llm_response.get(
+                "latency_ms",
+                int((time.time() - start_time) * 1000),
+            ),
         )
         db.add(assistant_chat)
         db.commit()
+        db.refresh(assistant_chat)
 
         logger.info(f"Chat processed successfully. Session ID: {user_chat.session_id}")
-        return {**response_data, "session_id": user_chat.session_id}
+        return {
+            **response_data,
+            "session_id": user_chat.session_id,
+            "assistant_message_id": assistant_chat.id,
+            "config_id": config.id if config else None,
+            "model": model,
+        }
 
     except HTTPException:
         # Re-raise HTTP exceptions
@@ -505,6 +577,9 @@ async def get_chat_history(
                 "session_id": h.session_id,
                 "role": h.role,
                 "content": h.content,
+                "config_id": h.config_id,
+                "model": h.model_name,
+                "latency_ms": h.latency_ms,
                 "created_at": h.created_at.isoformat()
             }
             for h in history

--- a/backend/app/routes_analytics.py
+++ b/backend/app/routes_analytics.py
@@ -1,0 +1,147 @@
+"""Internal analytics for the feedback-driven data flywheel."""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
+
+from .auth import verify_bearer_token
+from .db import SessionLocal
+from .models import ChatHistory, ChatbotConfig, Feedback
+
+router = APIRouter(prefix="/analytics", tags=["flywheel-analytics"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@router.get("/configurations")
+async def configuration_performance(
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    """Return response volume and approval metrics by chatbot configuration."""
+    response_rows = (
+        db.query(
+            ChatHistory.config_id,
+            func.max(ChatHistory.model_name).label("model_name"),
+            func.count(ChatHistory.id).label("total_responses"),
+            func.avg(ChatHistory.latency_ms).label("average_latency_ms"),
+        )
+        .filter(ChatHistory.role == "assistant")
+        .group_by(ChatHistory.config_id)
+        .all()
+    )
+
+    feedback_rows = (
+        db.query(
+            Feedback.config_id,
+            func.count(Feedback.id).label("rated_responses"),
+            func.sum(
+                case((Feedback.user_feedback == "thumbs_up", 1), else_=0)
+            ).label("positive_feedback"),
+            func.sum(
+                case((Feedback.user_feedback == "thumbs_down", 1), else_=0)
+            ).label("negative_feedback"),
+        )
+        .group_by(Feedback.config_id)
+        .all()
+    )
+
+    configs = {config.id: config for config in db.query(ChatbotConfig).all()}
+    feedback_by_config = {row.config_id: row for row in feedback_rows}
+    results = []
+
+    for row in response_rows:
+        feedback = feedback_by_config.get(row.config_id)
+        rated = int(feedback.rated_responses or 0) if feedback else 0
+        positive = int(feedback.positive_feedback or 0) if feedback else 0
+        negative = int(feedback.negative_feedback or 0) if feedback else 0
+        config = configs.get(row.config_id)
+
+        results.append(
+            {
+                "config_id": row.config_id,
+                "config_name": config.name if config else "Unattributed",
+                "model": row.model_name,
+                "total_responses": int(row.total_responses or 0),
+                "rated_responses": rated,
+                "positive_feedback": positive,
+                "negative_feedback": negative,
+                "approval_rate": round(positive / rated, 4) if rated else None,
+                "feedback_coverage": (
+                    round(rated / row.total_responses, 4)
+                    if row.total_responses
+                    else 0
+                ),
+                "average_latency_ms": (
+                    round(float(row.average_latency_ms), 1)
+                    if row.average_latency_ms is not None
+                    else None
+                ),
+            }
+        )
+
+    return sorted(
+        results,
+        key=lambda item: (
+            item["approval_rate"] is not None,
+            item["approval_rate"] or 0,
+            item["rated_responses"],
+        ),
+        reverse=True,
+    )
+
+
+@router.get("/negative-feedback")
+async def negative_feedback_examples(
+    limit: int = Query(20, ge=1, le=100),
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    """Return recent poorly rated responses with their originating prompt."""
+    rows = (
+        db.query(Feedback, ChatHistory, ChatbotConfig)
+        .outerjoin(ChatHistory, Feedback.response_id == ChatHistory.id)
+        .outerjoin(ChatbotConfig, Feedback.config_id == ChatbotConfig.id)
+        .filter(Feedback.user_feedback == "thumbs_down")
+        .order_by(Feedback.timestamp.desc())
+        .limit(limit)
+        .all()
+    )
+
+    results = []
+    for feedback, response, config in rows:
+        prompt = None
+        if response is not None:
+            prompt_message = (
+                db.query(ChatHistory)
+                .filter(
+                    ChatHistory.session_id == response.session_id,
+                    ChatHistory.role == "user",
+                    ChatHistory.id < response.id,
+                )
+                .order_by(ChatHistory.id.desc())
+                .first()
+            )
+            prompt = prompt_message.content if prompt_message else None
+
+        results.append(
+            {
+                "feedback_id": feedback.id,
+                "response_id": feedback.response_id,
+                "prompt": prompt,
+                "response": response.content if response else feedback.message,
+                "comment": feedback.comment,
+                "config_id": feedback.config_id,
+                "config_name": config.name if config else "Unattributed",
+                "model": response.model_name if response else None,
+                "timestamp": feedback.timestamp.isoformat(),
+            }
+        )
+
+    return results

--- a/backend/app/routes_analytics.py
+++ b/backend/app/routes_analytics.py
@@ -1,5 +1,7 @@
 """Internal analytics for the feedback-driven data flywheel."""
 
+from collections import defaultdict
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import case, func
 from sqlalchemy.orm import Session
@@ -114,19 +116,36 @@ async def negative_feedback_examples(
         .all()
     )
 
+    session_ids = {
+        response.session_id
+        for _, response, _ in rows
+        if response is not None and response.session_id
+    }
+    prompts_by_session = defaultdict(list)
+    if session_ids:
+        user_messages = (
+            db.query(ChatHistory)
+            .filter(
+                ChatHistory.session_id.in_(session_ids),
+                ChatHistory.role == "user",
+            )
+            .order_by(ChatHistory.session_id, ChatHistory.id.desc())
+            .all()
+        )
+        for message in user_messages:
+            prompts_by_session[message.session_id].append(message)
+
     results = []
     for feedback, response, config in rows:
         prompt = None
         if response is not None:
-            prompt_message = (
-                db.query(ChatHistory)
-                .filter(
-                    ChatHistory.session_id == response.session_id,
-                    ChatHistory.role == "user",
-                    ChatHistory.id < response.id,
-                )
-                .order_by(ChatHistory.id.desc())
-                .first()
+            prompt_message = next(
+                (
+                    message
+                    for message in prompts_by_session.get(response.session_id, [])
+                    if message.id < response.id
+                ),
+                None,
             )
             prompt = prompt_message.content if prompt_message else None
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -100,6 +100,11 @@ class FeedbackCreate(BaseModel):
         max_length=1000,
         description="Optional additional comment"
     )
+    response_id: Optional[int] = Field(
+        None,
+        ge=1,
+        description="Assistant chat-history message being rated",
+    )
 
 
 class ChatbotConfigBase(BaseModel):

--- a/backend/tests/test_chat_sessions.py
+++ b/backend/tests/test_chat_sessions.py
@@ -35,7 +35,7 @@ def mock_openai(monkeypatch):
     monkeypatch.setattr('app.routes.KnowledgeProcessor', lambda: mock_knowledge_processor)
 
     # Mock the LLM service to return test responses
-    def mock_llm_chat(messages, **kwargs):
+    async def mock_llm_chat(messages, **kwargs):
         user_message = messages[-1]['content'] if messages else "test"
         return {
             'content': f"Response to: {user_message}",
@@ -43,8 +43,8 @@ def mock_openai(monkeypatch):
             'latency_ms': 50
         }
 
-    # Patch the llm service
-    monkeypatch.setattr('app.routes.llm.chat', mock_llm_chat)
+    # routes.py imports chat directly, so patch the symbol used by the route.
+    monkeypatch.setattr('app.routes.chat', mock_llm_chat)
     yield
 
 def test_chat_without_session_id(mock_openai):

--- a/backend/tests/test_flywheel_analytics.py
+++ b/backend/tests/test_flywheel_analytics.py
@@ -1,7 +1,8 @@
 """Integration tests for response attribution and flywheel analytics."""
 
-from sqlalchemy import create_engine, inspect, text
+from sqlalchemy import create_engine, event, inspect, text
 
+from app.db import engine
 from app.migrations.add_flywheel_attribution import run_migration
 
 
@@ -92,6 +93,67 @@ def test_feedback_rejects_unknown_assistant_response(test_client):
     )
 
     assert response.status_code == 404
+
+
+def test_session_deletion_preserves_attributed_feedback(test_client, mock_llm):
+    chat_data = test_client.post(
+        "/api/v1/chat",
+        json={"message": "Response that will outlive its session"},
+    ).json()
+    feedback_response = test_client.post(
+        "/api/v1/feedback",
+        json={
+            "message": chat_data["reply"],
+            "response_id": chat_data["assistant_message_id"],
+            "user_feedback": "thumbs_down",
+            "comment": "Keep this feedback for aggregate analytics",
+        },
+    )
+    assert feedback_response.status_code == 201
+
+    delete_response = test_client.delete(
+        f"/api/v1/sessions/{chat_data['session_id']}"
+    )
+    assert delete_response.status_code == 200
+
+    feedback_entries = test_client.get("/api/v1/feedback").json()
+    assert len(feedback_entries) == 1
+    assert feedback_entries[0]["response_id"] is None
+    assert feedback_entries[0]["config_id"] == chat_data["config_id"]
+
+
+def test_negative_feedback_uses_bounded_query_count(test_client, mock_llm):
+    for index in range(3):
+        chat_data = test_client.post(
+            "/api/v1/chat",
+            json={"message": f"Prompt needing improvement {index}"},
+        ).json()
+        response = test_client.post(
+            "/api/v1/feedback",
+            json={
+                "message": chat_data["reply"],
+                "response_id": chat_data["assistant_message_id"],
+                "user_feedback": "thumbs_down",
+            },
+        )
+        assert response.status_code == 201
+
+    select_count = 0
+
+    def count_selects(_conn, _cursor, statement, _parameters, _context, _many):
+        nonlocal select_count
+        if statement.lstrip().upper().startswith("SELECT"):
+            select_count += 1
+
+    event.listen(engine, "before_cursor_execute", count_selects)
+    try:
+        response = test_client.get("/api/v1/analytics/negative-feedback")
+    finally:
+        event.remove(engine, "before_cursor_execute", count_selects)
+
+    assert response.status_code == 200
+    assert len(response.json()) == 3
+    assert select_count == 2
 
 
 def test_attribution_migration_upgrades_existing_database(tmp_path):

--- a/backend/tests/test_flywheel_analytics.py
+++ b/backend/tests/test_flywheel_analytics.py
@@ -1,0 +1,132 @@
+"""Integration tests for response attribution and flywheel analytics."""
+
+from sqlalchemy import create_engine, inspect, text
+
+from app.migrations.add_flywheel_attribution import run_migration
+
+
+def test_feedback_is_attributed_to_response_and_config(test_client, mock_llm):
+    chat_response = test_client.post(
+        "/api/v1/chat",
+        json={"message": "How should this response be evaluated?"},
+    )
+
+    assert chat_response.status_code == 200
+    chat_data = chat_response.json()
+    assert chat_data["assistant_message_id"] > 0
+    assert chat_data["config_id"] > 0
+    assert chat_data["model"] == "gpt-4o"
+
+    feedback_response = test_client.post(
+        "/api/v1/feedback",
+        json={
+            "message": chat_data["reply"],
+            "response_id": chat_data["assistant_message_id"],
+            "user_feedback": "thumbs_up",
+            "comment": "Relevant and clear",
+        },
+    )
+
+    assert feedback_response.status_code == 201
+
+    feedback_entries = test_client.get("/api/v1/feedback").json()
+    assert feedback_entries[0]["response_id"] == chat_data["assistant_message_id"]
+    assert feedback_entries[0]["config_id"] == chat_data["config_id"]
+
+
+def test_configuration_analytics_and_negative_examples(test_client, mock_llm):
+    positive_chat = test_client.post(
+        "/api/v1/chat",
+        json={"message": "Give me a concise answer"},
+    ).json()
+    negative_chat = test_client.post(
+        "/api/v1/chat",
+        json={"message": "Explain the deployment tradeoffs"},
+    ).json()
+
+    test_client.post(
+        "/api/v1/feedback",
+        json={
+            "message": positive_chat["reply"],
+            "response_id": positive_chat["assistant_message_id"],
+            "user_feedback": "thumbs_up",
+        },
+    )
+    test_client.post(
+        "/api/v1/feedback",
+        json={
+            "message": negative_chat["reply"],
+            "response_id": negative_chat["assistant_message_id"],
+            "user_feedback": "thumbs_down",
+            "comment": "It omitted the operational risks",
+        },
+    )
+
+    analytics_response = test_client.get("/api/v1/analytics/configurations")
+    assert analytics_response.status_code == 200
+    metrics = analytics_response.json()[0]
+    assert metrics["total_responses"] == 2
+    assert metrics["rated_responses"] == 2
+    assert metrics["positive_feedback"] == 1
+    assert metrics["negative_feedback"] == 1
+    assert metrics["approval_rate"] == 0.5
+    assert metrics["feedback_coverage"] == 1.0
+
+    negative_response = test_client.get("/api/v1/analytics/negative-feedback")
+    assert negative_response.status_code == 200
+    example = negative_response.json()[0]
+    assert example["response_id"] == negative_chat["assistant_message_id"]
+    assert example["prompt"] == "Explain the deployment tradeoffs"
+    assert example["comment"] == "It omitted the operational risks"
+    assert example["config_id"] == negative_chat["config_id"]
+
+
+def test_feedback_rejects_unknown_assistant_response(test_client):
+    response = test_client.post(
+        "/api/v1/feedback",
+        json={
+            "message": "Unknown response",
+            "response_id": 999999,
+            "user_feedback": "thumbs_down",
+        },
+    )
+
+    assert response.status_code == 404
+
+
+def test_attribution_migration_upgrades_existing_database(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'legacy.db'}")
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE chatbot_config "
+                "(id INTEGER PRIMARY KEY, name VARCHAR(100))"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE chat_history "
+                "(id INTEGER PRIMARY KEY, role VARCHAR(20), content TEXT)"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE TABLE feedback "
+                "(id INTEGER PRIMARY KEY, message TEXT, user_feedback VARCHAR(50))"
+            )
+        )
+
+    applied = run_migration(engine)
+
+    assert "chat_history.config_id" in applied
+    assert "feedback.response_id" in applied
+    assert {
+        "config_id",
+        "model_name",
+        "latency_ms",
+    }.issubset(
+        {column["name"] for column in inspect(engine).get_columns("chat_history")}
+    )
+    assert {"response_id", "config_id"}.issubset(
+        {column["name"] for column in inspect(engine).get_columns("feedback")}
+    )

--- a/backend/tests/test_streaming.py
+++ b/backend/tests/test_streaming.py
@@ -30,19 +30,21 @@ class TestStreamingIntegration:
         """
         Validate that tokens are generated incrementally during streaming.
         """
-        def mock_streaming_chat(messages, **kwargs):
-            tokens = ["Hello", " world", "!"]
-            for token in tokens:
-                yield token
+        async def mock_streaming_chat(messages, **kwargs):
+            async def token_generator():
+                tokens = ["Hello", " world", "!"]
+                for token in tokens:
+                    yield token
 
-            # Simulate end of stream metadata
-            yield json.dumps({
-                'content': "Hello world!",
-                'usage': {'total_tokens': len(tokens)},
-                'latency_ms': 50
-            })
+                yield {
+                    'content': "Hello world!",
+                    'usage': {'total_tokens': len(tokens)},
+                    'latency_ms': 50
+                }
 
-        with patch('app.services.llm.chat', side_effect=mock_streaming_chat):
+            return token_generator()
+
+        with patch('app.routes.chat', side_effect=mock_streaming_chat):
             payload = {
                 "message": "Generate streaming response",
                 "stream": True
@@ -83,6 +85,8 @@ class TestStreamingIntegration:
             full_response = streamed_data[-1]
             assert 'reply' in full_response
             assert len(full_response['reply']) > 0
+            assert full_response['assistant_message_id'] > 0
+            assert full_response['config_id'] > 0
 
     def test_streaming_knowledge_sources(self, test_client, mock_knowledge_processor):
         """
@@ -127,7 +131,7 @@ class TestStreamingIntegration:
         """
         Ensure streaming errors are properly handled and returned.
         """
-        with patch('app.services.llm.chat', side_effect=Exception("Streaming simulation error")):
+        with patch('app.routes.chat', side_effect=Exception("Streaming simulation error")):
             payload = {
                 "message": "Trigger streaming error",
                 "stream": True

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,11 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./backend/app:/app
-      - ./frontend:/frontend
+      - ./backend:/app/backend
+      - ./frontend:/app/frontend
     env_file:
-      - .env
+      - path: .env
+        required: false
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-sk-test-key-for-testing}
       - DATABASE_URL=${DATABASE_URL:-sqlite:///./chatbot.db}
@@ -47,8 +48,10 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ./backend/app:/app
-      - ./tests:/tests
+      - ./backend:/app/backend
+      - ./frontend:/app/frontend
+      - ./tests:/app/tests
+      - ./pytest.ini:/app/pytest.ini
     environment:
       - OPENAI_API_KEY=sk-test-key-for-testing
       - DATABASE_URL=sqlite:///./test_chatbot.db
@@ -56,7 +59,8 @@ services:
       - DEFAULT_TEMPERATURE=0.7
       - CORS_ORIGINS=["*"]
       - DEBUG=true
-    command: ["python", "-m", "pytest", "/tests/", "-q", "--tb=short"]
+    working_dir: /app
+    command: ["python", "-m", "pytest", "-q", "--tb=short"]
     profiles:
       - test
 

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -114,7 +114,9 @@ function formatTimestamp(timestamp) {
 function createMessageElement(content, type, timestamp = null, sources = null, messageId = null) {
     const messageDiv = document.createElement('div');
     messageDiv.className = `message ${type}`;
-    messageDiv.dataset.messageId = messageId;
+    if (messageId !== null && messageId !== undefined) {
+        messageDiv.dataset.messageId = String(messageId);
+    }
     
     const contentDiv = document.createElement('div');
     contentDiv.className = 'message-content';
@@ -172,7 +174,12 @@ function createMessageElement(content, type, timestamp = null, sources = null, m
                             showStatus('Message not ready for feedback yet', 'error');
                             return;
                         }
-                        submitMessageFeedback(messageText, feedback, commentInput.value);
+                        submitMessageFeedback(
+                            messageText,
+                            feedback,
+                            commentInput.value,
+                            messageDiv.dataset.messageId
+                        );
                         commentInput.removeEventListener('blur', submitFeedback);
                         commentInput.removeEventListener('keypress', handleEnter);
                     };
@@ -241,7 +248,8 @@ async function sendMessage(useStreaming = true) {
                 response.reply,
                 'assistant',
                 new Date().toISOString(),
-                response.knowledge_sources
+                response.knowledge_sources,
+                response.assistant_message_id
             );
 
         } catch (error) {
@@ -320,6 +328,11 @@ async function sendMessage(useStreaming = true) {
                             highlightSession(currentSessionId);
                         }
 
+                        if (data.assistant_message_id) {
+                            assistantMessageElement.dataset.messageId =
+                                String(data.assistant_message_id);
+                        }
+
                         // Handle potential error response
                         if (data.error) {
                             throw new Error(data.error);
@@ -385,8 +398,13 @@ async function loadChatHistory() {
         
         // Add history messages in chronological order
         history.reverse().forEach(entry => {
-            addMessage(entry.user_message, 'user', entry.timestamp, null, entry.id);
-            addMessage(entry.bot_reply, 'assistant', entry.timestamp, null, entry.id);
+            addMessage(
+                entry.content,
+                entry.role,
+                entry.created_at,
+                null,
+                entry.id
+            );
         });
         
         showStatus(`Loaded ${history.length} recent conversations`, 'success');
@@ -398,7 +416,7 @@ async function loadChatHistory() {
     }
 }
 
-async function submitMessageFeedback(message, feedback, comment = '') {
+async function submitMessageFeedback(message, feedback, comment = '', responseId = null) {
     try {
         const sanitizedMessage = (message || '').trim();
         if (!sanitizedMessage) {
@@ -406,11 +424,17 @@ async function submitMessageFeedback(message, feedback, comment = '') {
             return;
         }
 
-        await api.post('/feedback', {
+        const payload = {
             message: sanitizedMessage,
             user_feedback: feedback,
             comment: (comment || '').trim() || null
-        });
+        };
+        const parsedResponseId = Number(responseId);
+        if (Number.isInteger(parsedResponseId) && parsedResponseId > 0) {
+            payload.response_id = parsedResponseId;
+        }
+
+        await api.post('/feedback', payload);
 
         showStatus('Feedback submitted successfully', 'success');
     } catch (error) {

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -11,27 +11,35 @@ const api = {
             return `${configured.replace(/\/$/, '')}/api/v1`;
         }
 
-        const { protocol, hostname, port } = window.location;
+        const { protocol, origin } = window.location;
         if (protocol === 'file:') {
             return 'http://localhost:8000/api/v1';
         }
 
-        const isLocal = hostname === 'localhost' || hostname === '127.0.0.1';
-
-        if (isLocal) {
-            return `${protocol}//${hostname}:8000/api/v1`;
-        }
-
-        return `${protocol}//${hostname}${port ? `:${port}` : ''}/api/v1`;
+        return `${origin}/api/v1`;
     })(),
-    
+
+    getToken() {
+        return window.sessionStorage.getItem('flywheelAppToken') || '';
+    },
+
+    buildHeaders(includeJson = false) {
+        const headers = {};
+        if (includeJson) {
+            headers['Content-Type'] = 'application/json';
+        }
+        const token = this.getToken();
+        if (token) {
+            headers.Authorization = `Bearer ${token}`;
+        }
+        return headers;
+    },
+
     async post(path, body) {
         console.log('API POST to:', `${this.baseUrl}${path}`);
         const response = await fetch(`${this.baseUrl}${path}`, {
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
+            headers: this.buildHeaders(true),
             body: JSON.stringify(body)
         });
         return this.handleResponse(response);
@@ -41,20 +49,24 @@ const api = {
         console.log('API POST FILE to:', `${this.baseUrl}${path}`);
         const response = await fetch(`${this.baseUrl}${path}`, {
             method: 'POST',
+            headers: this.buildHeaders(),
             body: formData
         });
         return this.handleResponse(response);
     },
     
     async get(path) {
-        const response = await fetch(`${this.baseUrl}${path}`);
+        const response = await fetch(`${this.baseUrl}${path}`, {
+            headers: this.buildHeaders()
+        });
         return this.handleResponse(response);
     },
 
     async delete(path) {
         console.log('API DELETE to:', `${this.baseUrl}${path}`);
         const response = await fetch(`${this.baseUrl}${path}`, {
-            method: 'DELETE'
+            method: 'DELETE',
+            headers: this.buildHeaders()
         });
         return this.handleResponse(response);
     },
@@ -78,7 +90,21 @@ const elements = {
     historyBtn: document.getElementById('historyBtn'),
     status: document.getElementById('status'),
     sessionsList: document.getElementById('sessionsList'),
-    newChatBtn: document.getElementById('newChatBtn')
+    newChatBtn: document.getElementById('newChatBtn'),
+    chatView: document.getElementById('chatView'),
+    analyticsView: document.getElementById('analyticsView'),
+    chatViewBtn: document.getElementById('chatViewBtn'),
+    analyticsViewBtn: document.getElementById('analyticsViewBtn'),
+    analyticsToken: document.getElementById('analyticsToken'),
+    saveTokenBtn: document.getElementById('saveTokenBtn'),
+    refreshAnalyticsBtn: document.getElementById('refreshAnalyticsBtn'),
+    analyticsStatus: document.getElementById('analyticsStatus'),
+    configurationAnalytics: document.getElementById('configurationAnalytics'),
+    negativeFeedbackList: document.getElementById('negativeFeedbackList'),
+    totalResponsesMetric: document.getElementById('totalResponsesMetric'),
+    ratedResponsesMetric: document.getElementById('ratedResponsesMetric'),
+    approvalRateMetric: document.getElementById('approvalRateMetric'),
+    feedbackCoverageMetric: document.getElementById('feedbackCoverageMetric')
 };
 
 // Application state
@@ -108,6 +134,22 @@ function scrollToBottom() {
 
 function formatTimestamp(timestamp) {
     return new Date(timestamp).toLocaleTimeString();
+}
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#039;');
+}
+
+function formatPercent(value) {
+    if (value === null || value === undefined) {
+        return '—';
+    }
+    return `${Math.round(value * 100)}%`;
 }
 
 // Message rendering functions
@@ -275,7 +317,7 @@ async function sendMessage(useStreaming = true) {
         const response = await fetch(`${api.baseUrl}/chat`, {
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json'
+                ...api.buildHeaders(true)
             },
             body: JSON.stringify({
                 message,
@@ -552,7 +594,7 @@ async function switchToSession(sessionId) {
 
         // Add messages in chronological order
         sessionMessages.reverse().forEach(entry => {
-            addMessage(entry.content, entry.role, entry.created_at);
+            addMessage(entry.content, entry.role, entry.created_at, null, entry.id);
         });
 
         // Update current session
@@ -595,6 +637,8 @@ async function deleteSession(sessionId) {
 }
 
 function startNewChat() {
+    setActiveView('chat');
+
     // Clear current session
     currentSessionId = null;
 
@@ -621,6 +665,161 @@ function startNewChat() {
     showStatus('Started new chat', 'success');
 }
 
+// =============================
+// Flywheel Analytics
+// =============================
+
+function showAnalyticsStatus(message, type = 'success') {
+    elements.analyticsStatus.innerHTML =
+        `<div class="status ${type}">${escapeHtml(message)}</div>`;
+}
+
+function setActiveView(viewName) {
+    const showingAnalytics = viewName === 'analytics';
+    elements.chatView.classList.toggle('hidden', showingAnalytics);
+    elements.analyticsView.classList.toggle('hidden', !showingAnalytics);
+    elements.chatViewBtn.classList.toggle('active', !showingAnalytics);
+    elements.analyticsViewBtn.classList.toggle('active', showingAnalytics);
+
+    if (showingAnalytics) {
+        loadAnalytics();
+    } else {
+        elements.messageInput.focus();
+    }
+}
+
+function renderConfigurationAnalytics(configurations) {
+    if (!configurations.length) {
+        elements.configurationAnalytics.innerHTML =
+            '<div class="dashboard-empty">No attributed responses yet. Send a chat message and rate the response.</div>';
+        return;
+    }
+
+    const rows = configurations.map(config => {
+        const approvalWidth = config.approval_rate === null
+            ? 0
+            : Math.round(config.approval_rate * 100);
+        return `
+            <tr>
+                <td>
+                    <strong>${escapeHtml(config.config_name)}</strong><br>
+                    <span>${escapeHtml(config.model || 'Unknown model')}</span>
+                </td>
+                <td>${config.total_responses}</td>
+                <td>${config.rated_responses}</td>
+                <td>
+                    ${formatPercent(config.approval_rate)}
+                    <div class="rate-bar" aria-hidden="true">
+                        <span style="width: ${approvalWidth}%"></span>
+                    </div>
+                </td>
+                <td>${formatPercent(config.feedback_coverage)}</td>
+                <td>${config.average_latency_ms === null ? '—' : `${config.average_latency_ms} ms`}</td>
+            </tr>
+        `;
+    }).join('');
+
+    elements.configurationAnalytics.innerHTML = `
+        <table class="analytics-table">
+            <thead>
+                <tr>
+                    <th>Configuration</th>
+                    <th>Responses</th>
+                    <th>Rated</th>
+                    <th>Approval</th>
+                    <th>Coverage</th>
+                    <th>Avg. latency</th>
+                </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+        </table>
+    `;
+}
+
+function renderNegativeFeedback(examples) {
+    if (!examples.length) {
+        elements.negativeFeedbackList.innerHTML =
+            '<div class="dashboard-empty">No negative feedback has been attributed yet.</div>';
+        return;
+    }
+
+    elements.negativeFeedbackList.innerHTML = examples.map(example => `
+        <article class="negative-item">
+            <div class="negative-meta">
+                <span>Config: ${escapeHtml(example.config_name)}</span>
+                <span>Model: ${escapeHtml(example.model || 'Unknown')}</span>
+                <span>${escapeHtml(new Date(example.timestamp).toLocaleString())}</span>
+            </div>
+            <div class="negative-prompt">
+                <strong>Prompt:</strong> ${escapeHtml(example.prompt || 'Unavailable')}
+            </div>
+            <div class="negative-response">
+                <strong>Response:</strong> ${escapeHtml(example.response)}
+            </div>
+            <div class="negative-comment">
+                <strong>User comment:</strong> ${escapeHtml(example.comment || 'No comment supplied')}
+            </div>
+        </article>
+    `).join('');
+}
+
+function renderSummaryMetrics(configurations) {
+    const totals = configurations.reduce((summary, config) => {
+        summary.responses += config.total_responses;
+        summary.rated += config.rated_responses;
+        summary.positive += config.positive_feedback;
+        return summary;
+    }, { responses: 0, rated: 0, positive: 0 });
+
+    elements.totalResponsesMetric.textContent = String(totals.responses);
+    elements.ratedResponsesMetric.textContent = String(totals.rated);
+    elements.approvalRateMetric.textContent = totals.rated
+        ? formatPercent(totals.positive / totals.rated)
+        : '—';
+    elements.feedbackCoverageMetric.textContent = totals.responses
+        ? formatPercent(totals.rated / totals.responses)
+        : '0%';
+}
+
+async function loadAnalytics() {
+    elements.refreshAnalyticsBtn.disabled = true;
+    showAnalyticsStatus('Loading analytics...');
+
+    try {
+        const [configurations, negativeFeedback] = await Promise.all([
+            api.get('/analytics/configurations'),
+            api.get('/analytics/negative-feedback?limit=20')
+        ]);
+
+        renderSummaryMetrics(configurations);
+        renderConfigurationAnalytics(configurations);
+        renderNegativeFeedback(negativeFeedback);
+        showAnalyticsStatus(`Loaded ${configurations.length} configuration result(s).`);
+    } catch (error) {
+        const needsToken = /403|token|credentials/i.test(error.message);
+        showAnalyticsStatus(
+            needsToken
+                ? 'Analytics access requires the APP_TOKEN configured on the server.'
+                : `Analytics error: ${error.message}`,
+            'error'
+        );
+    } finally {
+        elements.refreshAnalyticsBtn.disabled = false;
+    }
+}
+
+function saveAnalyticsToken() {
+    const token = elements.analyticsToken.value.trim();
+    if (token) {
+        window.sessionStorage.setItem('flywheelAppToken', token);
+        showAnalyticsStatus('Token saved for this browser session.');
+    } else {
+        window.sessionStorage.removeItem('flywheelAppToken');
+        showAnalyticsStatus('Stored token cleared.');
+    }
+    loadAnalytics();
+}
+
 // Event listeners
 elements.sendBtn.addEventListener('click', sendMessage);
 elements.messageInput.addEventListener('keypress', (e) => {
@@ -632,8 +831,13 @@ elements.messageInput.addEventListener('keypress', (e) => {
 elements.uploadBtn.addEventListener('click', uploadFile);
 elements.historyBtn.addEventListener('click', loadChatHistory);
 elements.newChatBtn.addEventListener('click', startNewChat);
+elements.chatViewBtn.addEventListener('click', () => setActiveView('chat'));
+elements.analyticsViewBtn.addEventListener('click', () => setActiveView('analytics'));
+elements.refreshAnalyticsBtn.addEventListener('click', loadAnalytics);
+elements.saveTokenBtn.addEventListener('click', saveAnalyticsToken);
 
 // Initialize
 console.log('Data Flywheel Chatbot initialized');
+elements.analyticsToken.value = api.getToken();
 loadSessions(); // Load sessions on startup
 elements.messageInput.focus();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -54,6 +54,34 @@
             background: #0056b3;
         }
 
+        .sidebar-nav {
+            display: grid;
+            gap: 8px;
+            padding: 14px 12px;
+            border-bottom: 1px solid #dee2e6;
+        }
+
+        .nav-btn {
+            padding: 10px 12px;
+            border: 1px solid transparent;
+            border-radius: 6px;
+            background: transparent;
+            color: #495057;
+            cursor: pointer;
+            text-align: left;
+            font-weight: 600;
+        }
+
+        .nav-btn:hover {
+            background: #f1f3f5;
+        }
+
+        .nav-btn.active {
+            background: #e7f1ff;
+            border-color: #b6d4fe;
+            color: #0b5ed7;
+        }
+
         .sessions-list {
             flex: 1;
             overflow-y: auto;
@@ -131,6 +159,10 @@
             flex-direction: column;
             padding: 20px;
             overflow: auto;
+        }
+
+        .view.hidden {
+            display: none;
         }
 
         .header {
@@ -307,6 +339,232 @@
             opacity: 0.6;
             pointer-events: none;
         }
+
+        .dashboard-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 20px;
+            align-items: flex-start;
+            margin-bottom: 20px;
+            padding: 24px;
+            background: #182433;
+            color: white;
+            border-radius: 10px;
+        }
+
+        .dashboard-header p {
+            color: #cbd5e1;
+            margin-top: 6px;
+        }
+
+        .dashboard-actions {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+        }
+
+        .token-input {
+            min-width: 220px;
+            padding: 9px 11px;
+            border: 1px solid #64748b;
+            border-radius: 5px;
+            background: #f8fafc;
+            color: #172033;
+        }
+
+        .dashboard-grid {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(150px, 1fr));
+            gap: 14px;
+            margin-bottom: 20px;
+        }
+
+        .metric-card,
+        .dashboard-panel {
+            background: white;
+            border: 1px solid #e2e8f0;
+            border-radius: 9px;
+            box-shadow: 0 2px 8px rgba(15, 23, 42, 0.05);
+        }
+
+        .metric-card {
+            padding: 18px;
+        }
+
+        .metric-label {
+            color: #64748b;
+            font-size: 12px;
+            font-weight: 700;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+        }
+
+        .metric-value {
+            display: block;
+            margin-top: 8px;
+            color: #172033;
+            font-size: 28px;
+            font-weight: 750;
+            line-height: 1.1;
+        }
+
+        .dashboard-panel {
+            margin-bottom: 20px;
+            overflow: hidden;
+        }
+
+        .panel-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+            padding: 16px 18px;
+            border-bottom: 1px solid #e2e8f0;
+        }
+
+        .panel-header p {
+            color: #64748b;
+            font-size: 13px;
+        }
+
+        .analytics-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .analytics-table th,
+        .analytics-table td {
+            padding: 12px 14px;
+            border-bottom: 1px solid #edf2f7;
+            text-align: left;
+            font-size: 13px;
+        }
+
+        .analytics-table th {
+            color: #64748b;
+            background: #f8fafc;
+            font-size: 11px;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
+
+        .analytics-table tr:last-child td {
+            border-bottom: 0;
+        }
+
+        .rate-bar {
+            width: 110px;
+            height: 7px;
+            margin-top: 5px;
+            overflow: hidden;
+            background: #e2e8f0;
+            border-radius: 99px;
+        }
+
+        .rate-bar span {
+            display: block;
+            height: 100%;
+            background: #198754;
+            border-radius: inherit;
+        }
+
+        .negative-list {
+            display: grid;
+            gap: 12px;
+            padding: 16px;
+        }
+
+        .negative-item {
+            padding: 15px;
+            border: 1px solid #fecaca;
+            border-left: 4px solid #dc3545;
+            border-radius: 7px;
+            background: #fffafa;
+        }
+
+        .negative-meta {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            margin-bottom: 9px;
+            color: #64748b;
+            font-size: 12px;
+        }
+
+        .negative-prompt,
+        .negative-response,
+        .negative-comment {
+            margin-top: 7px;
+            white-space: pre-wrap;
+        }
+
+        .negative-item strong {
+            color: #172033;
+        }
+
+        .dashboard-empty {
+            padding: 28px;
+            color: #64748b;
+            text-align: center;
+        }
+
+        @media (max-width: 900px) {
+            body {
+                height: auto;
+                min-height: 100vh;
+            }
+
+            .sidebar {
+                width: 210px;
+            }
+
+            .dashboard-grid {
+                grid-template-columns: repeat(2, minmax(140px, 1fr));
+            }
+
+            .dashboard-header {
+                flex-direction: column;
+            }
+
+            .dashboard-actions {
+                justify-content: flex-start;
+            }
+        }
+
+        @media (max-width: 650px) {
+            body {
+                display: block;
+            }
+
+            .sidebar {
+                width: 100%;
+                max-height: 280px;
+                border-right: 0;
+                border-bottom: 1px solid #dee2e6;
+            }
+
+            .sidebar-nav {
+                grid-template-columns: 1fr 1fr;
+            }
+
+            .container {
+                padding: 12px;
+            }
+
+            .dashboard-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .analytics-table {
+                min-width: 720px;
+            }
+
+            .dashboard-panel {
+                overflow-x: auto;
+            }
+        }
     </style>
 </head>
 <body>
@@ -316,6 +574,10 @@
             <h2>Chat Sessions</h2>
             <button class="new-chat-btn" id="newChatBtn">+ New Chat</button>
         </div>
+        <nav class="sidebar-nav" aria-label="Application views">
+            <button class="nav-btn active" id="chatViewBtn">Chat</button>
+            <button class="nav-btn" id="analyticsViewBtn">Flywheel Analytics</button>
+        </nav>
         <div class="sessions-list" id="sessionsList">
             <!-- Sessions will be dynamically loaded here -->
         </div>
@@ -323,37 +585,98 @@
 
     <!-- Main Content -->
     <div class="container">
-        <div class="header">
-            <h1>Data Flywheel Chatbot</h1>
-            <p>Upload knowledge files and chat with an AI assistant that can reference your documents</p>
-        </div>
-
-        <div class="chat-container">
-            <div class="messages" id="messages">
-                <div class="message assistant">
-                    <div class="message-content">
-                        Hello! I'm your AI assistant. You can upload knowledge files and ask me questions about them.
-                    </div>
-                </div>
+        <main class="view" id="chatView">
+            <div class="header">
+                <h1>Data Flywheel Chatbot</h1>
+                <p>Upload knowledge files and chat with an AI assistant that can reference your documents</p>
             </div>
 
-            <div class="input-section">
-                <div class="chat-input">
-                    <input type="text" id="messageInput" placeholder="Type your message here..." maxlength="4000">
-                    <button class="btn" id="sendBtn">Send</button>
-                </div>
-
-                <div class="controls">
-                    <div class="file-upload">
-                        <input type="file" id="fileInput" accept=".txt,.pdf" title="Upload TXT or PDF files">
-                        <button class="btn" id="uploadBtn">Upload</button>
+            <div class="chat-container">
+                <div class="messages" id="messages">
+                    <div class="message assistant">
+                        <div class="message-content">
+                            Hello! I'm your AI assistant. You can upload knowledge files and ask me questions about them.
+                        </div>
                     </div>
-                    <button class="btn" id="historyBtn">Load Recent</button>
                 </div>
 
-                <div id="status"></div>
+                <div class="input-section">
+                    <div class="chat-input">
+                        <input type="text" id="messageInput" placeholder="Type your message here..." maxlength="4000">
+                        <button class="btn" id="sendBtn">Send</button>
+                    </div>
+
+                    <div class="controls">
+                        <div class="file-upload">
+                            <input type="file" id="fileInput" accept=".txt,.pdf" title="Upload TXT or PDF files">
+                            <button class="btn" id="uploadBtn">Upload</button>
+                        </div>
+                        <button class="btn" id="historyBtn">Load Recent</button>
+                    </div>
+
+                    <div id="status"></div>
+                </div>
             </div>
-        </div>
+        </main>
+
+        <main class="view hidden" id="analyticsView">
+            <section class="dashboard-header">
+                <div>
+                    <h1>Flywheel Analytics</h1>
+                    <p>See which configurations produce useful responses and where the system needs improvement.</p>
+                </div>
+                <div class="dashboard-actions">
+                    <input class="token-input" id="analyticsToken" type="password" placeholder="APP_TOKEN (if configured)" autocomplete="off">
+                    <button class="btn" id="saveTokenBtn">Use token</button>
+                    <button class="btn" id="refreshAnalyticsBtn">Refresh</button>
+                </div>
+            </section>
+
+            <div class="dashboard-grid" aria-label="Flywheel summary metrics">
+                <article class="metric-card">
+                    <span class="metric-label">Responses</span>
+                    <span class="metric-value" id="totalResponsesMetric">—</span>
+                </article>
+                <article class="metric-card">
+                    <span class="metric-label">Rated responses</span>
+                    <span class="metric-value" id="ratedResponsesMetric">—</span>
+                </article>
+                <article class="metric-card">
+                    <span class="metric-label">Approval rate</span>
+                    <span class="metric-value" id="approvalRateMetric">—</span>
+                </article>
+                <article class="metric-card">
+                    <span class="metric-label">Feedback coverage</span>
+                    <span class="metric-value" id="feedbackCoverageMetric">—</span>
+                </article>
+            </div>
+
+            <section class="dashboard-panel">
+                <div class="panel-header">
+                    <div>
+                        <h2>Configuration performance</h2>
+                        <p>Response quality, coverage, volume, and latency by active configuration.</p>
+                    </div>
+                </div>
+                <div id="configurationAnalytics">
+                    <div class="dashboard-empty">Open the dashboard to load configuration metrics.</div>
+                </div>
+            </section>
+
+            <section class="dashboard-panel">
+                <div class="panel-header">
+                    <div>
+                        <h2>Negative feedback queue</h2>
+                        <p>Review the prompt, response, and comment before refining a configuration.</p>
+                    </div>
+                </div>
+                <div class="negative-list" id="negativeFeedbackList">
+                    <div class="dashboard-empty">No feedback examples loaded.</div>
+                </div>
+            </section>
+
+            <div id="analyticsStatus"></div>
+        </main>
     </div>
 
     <script type="module" src="app.js"></script>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 # Test discovery
 testpaths = tests backend/tests
 python_files = test_*.py *_test.py
@@ -14,8 +14,9 @@ addopts =
 # Filter warnings
 filterwarnings =
     ignore::DeprecationWarning:fastapi.*
-    ignore::PydanticDeprecatedSince20:pydantic.*
-    ignore::MovedIn20Warning:sqlalchemy.*
+    ignore:The 'app' shortcut is now deprecated:DeprecationWarning:httpx.*
+    ignore::pydantic.PydanticDeprecatedSince20
+    ignore::sqlalchemy.exc.MovedIn20Warning
     ignore::pytest.PytestUnraisableExceptionWarning
 
 # Markers
@@ -24,6 +25,7 @@ markers =
     integration: marks tests as integration tests requiring external services
     frontend: marks tests as frontend-specific tests
     knowledge: marks tests as knowledge integration tests
+    streaming: marks tests as streaming feature tests
     unit: marks tests as unit tests (isolated)
 
 # Minimum version

--- a/tests/test_frontend_integration.py
+++ b/tests/test_frontend_integration.py
@@ -35,6 +35,21 @@ class TestFrontendIntegration:
         data = response.json()
         assert "version" in data
 
+    def test_analytics_dashboard_shell(self, test_client):
+        """The frontend exposes the internal flywheel analytics view."""
+        response = test_client.get("/")
+
+        assert response.status_code == 200
+        assert 'id="analyticsView"' in response.text
+        assert 'id="configurationAnalytics"' in response.text
+        assert 'id="negativeFeedbackList"' in response.text
+        assert 'id="analyticsToken"' in response.text
+
+        script_response = test_client.get("/app.js")
+        assert script_response.status_code == 200
+        assert "window.location" in script_response.text
+        assert "return `${origin}/api/v1`" in script_response.text
+
     # API Accessibility Tests
 
     def test_api_endpoints_accessible(self, test_client):


### PR DESCRIPTION
## What changed

- attributes each assistant response and feedback item to the chatbot configuration and model used
- adds backward-compatible database migration support for attribution fields
- adds configuration performance and negative-feedback analytics endpoints
- adds an internal responsive analytics dashboard with session-scoped token access
- expands CI to run the complete backend and frontend test suite

## Why

The project collected feedback but did not connect it to the response or configuration that produced it. This change establishes the data lineage needed for a real feedback flywheel and makes the resulting performance signals visible to reviewers and operators.

## Impact

Operators can compare response volume, approval rate, feedback coverage, and latency by configuration, then inspect negatively rated prompt/response pairs before refining prompts or introducing A/B tests.

## Validation

- Docker test suite: 19 passed, 20 skipped
- Python source compilation passed
- frontend JavaScript syntax check passed
- database startup and legacy SQLite migration verified
- dashboard visually verified at desktop and mobile viewport sizes