### PR TITLE
[codex] add A/B configuration experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
 - **Feedback Attribution**: Link each rating to the exact assistant response, model, and chatbot configuration that produced it
 - **Flywheel Analytics**: Compare approval rate, feedback coverage, response volume, and latency by configuration
 - **Internal Dashboard**: Review configuration metrics and negative feedback examples directly in the web interface
+- **A/B Configuration Routing**: Run weighted experiments across prompt/model configurations with deterministic, session-sticky assignment
+- **Experiment Operations**: Create configurations, launch or pause experiments, and compare target allocation with observed quality metrics from the dashboard
 - **Time Utility Endpoint**: Quickly fetch the current UTC timestamp via the lightweight `/current_time` endpoint
 - **RESTful API**: Clean, well-documented API endpoints with automatic OpenAPI documentation
 - **Error Handling & Logging**: Comprehensive error handling with structured logging
@@ -192,6 +194,11 @@ automatically.
 #### Flywheel Analytics
 - `GET /api/v1/analytics/configurations` - Configuration-level response and feedback metrics
 - `GET /api/v1/analytics/negative-feedback` - Recent negative examples with prompt, response, model, and configuration
+- `GET /api/v1/analytics/experiments` - Experiment allocation, approval, coverage, and latency by variant
+- `GET /api/v1/experiments` - List configuration experiments
+- `POST /api/v1/experiments` - Create a weighted experiment draft
+- `POST /api/v1/experiments/{id}/activate` - Route new sessions through an experiment
+- `POST /api/v1/experiments/{id}/pause` - Stop assigning new sessions while preserving attribution
 
 Analytics endpoints require `Authorization: Bearer <APP_TOKEN>` when
 `APP_TOKEN` is configured.

--- a/backend/app/experiments.py
+++ b/backend/app/experiments.py
@@ -1,0 +1,94 @@
+"""Configuration experiment selection and validation helpers."""
+
+import hashlib
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from .models import ChatHistory, ChatbotConfig, Experiment
+
+
+def validate_experiment_configs(db: Session, variants: list[dict]) -> None:
+    """Require every experiment variant to reference an active configuration."""
+    config_ids = {variant["config_id"] for variant in variants}
+    active_ids = {
+        config.id
+        for config in db.query(ChatbotConfig)
+        .filter(
+            ChatbotConfig.id.in_(config_ids),
+            ChatbotConfig.is_active.is_(True),
+        )
+        .all()
+    }
+    missing = sorted(config_ids - active_ids)
+    if missing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Experiment variants must reference active configurations: {missing}",
+        )
+
+
+def choose_weighted_variant(experiment: Experiment, session_id: str) -> int:
+    """Choose a deterministic weighted variant for a session."""
+    digest = hashlib.sha256(
+        f"{experiment.id}:{session_id}".encode("utf-8")
+    ).digest()
+    bucket = int.from_bytes(digest[:8], "big") % 100
+    cumulative = 0
+    for variant in experiment.variants:
+        cumulative += int(variant["weight"])
+        if bucket < cumulative:
+            return int(variant["config_id"])
+    return int(experiment.variants[-1]["config_id"])
+
+
+def select_chat_configuration(
+    db: Session,
+    session_id: str,
+) -> tuple[ChatbotConfig | None, Experiment | None]:
+    """Return the sticky session variant or assign the active experiment."""
+    previous = (
+        db.query(ChatHistory)
+        .filter(
+            ChatHistory.session_id == session_id,
+            ChatHistory.config_id.is_not(None),
+        )
+        .order_by(ChatHistory.id.asc())
+        .first()
+    )
+    if previous:
+        config = db.query(ChatbotConfig).filter(ChatbotConfig.id == previous.config_id).first()
+        experiment = (
+            db.query(Experiment).filter(Experiment.id == previous.experiment_id).first()
+            if previous.experiment_id
+            else None
+        )
+        if config:
+            return config, experiment
+
+    experiment = (
+        db.query(Experiment)
+        .filter(Experiment.status == "active")
+        .order_by(Experiment.updated_at.desc(), Experiment.id.desc())
+        .first()
+    )
+    if experiment:
+        config_id = choose_weighted_variant(experiment, session_id)
+        config = (
+            db.query(ChatbotConfig)
+            .filter(
+                ChatbotConfig.id == config_id,
+                ChatbotConfig.is_active.is_(True),
+            )
+            .first()
+        )
+        if config:
+            return config, experiment
+
+    config = (
+        db.query(ChatbotConfig)
+        .filter(ChatbotConfig.is_active.is_(True))
+        .order_by(ChatbotConfig.updated_at.desc())
+        .first()
+    )
+    return config, None

--- a/backend/app/experiments.py
+++ b/backend/app/experiments.py
@@ -45,17 +45,20 @@ def choose_weighted_variant(experiment: Experiment, session_id: str) -> int:
 def select_chat_configuration(
     db: Session,
     session_id: str,
+    is_new_session: bool = False,
 ) -> tuple[ChatbotConfig | None, Experiment | None]:
     """Return the sticky session variant or assign the active experiment."""
-    previous = (
-        db.query(ChatHistory)
-        .filter(
-            ChatHistory.session_id == session_id,
-            ChatHistory.config_id.is_not(None),
+    previous = None
+    if not is_new_session:
+        previous = (
+            db.query(ChatHistory)
+            .filter(
+                ChatHistory.session_id == session_id,
+                ChatHistory.config_id.is_not(None),
+            )
+            .order_by(ChatHistory.id.asc())
+            .first()
         )
-        .order_by(ChatHistory.id.asc())
-        .first()
-    )
     if previous:
         config = db.query(ChatbotConfig).filter(ChatbotConfig.id == previous.config_id).first()
         experiment = (

--- a/backend/app/init_db.py
+++ b/backend/app/init_db.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from sqlalchemy.engine.url import make_url
 
 from .db import Base, engine
-from .models import Feedback, ChatHistory, ChatbotConfig, KnowledgeFile  # noqa: F401
+from .models import Feedback, ChatHistory, ChatbotConfig, Experiment, KnowledgeFile  # noqa: F401
 from .utils import setup_logging
 
 # Initialize logging

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from .routes import router
 from .routes_configs import router as configs_router
 from .routes_knowledge import router as knowledge_router
 from .routes_analytics import router as analytics_router
+from .routes_experiments import router as experiments_router
 from .demo_seed import seed_demo
 from .init_db import init_database
 
@@ -129,6 +130,7 @@ app.include_router(router, prefix="/api/v1")
 app.include_router(configs_router, prefix="/api/v1")
 app.include_router(knowledge_router, prefix="/api/v1")
 app.include_router(analytics_router, prefix="/api/v1")
+app.include_router(experiments_router, prefix="/api/v1")
 
 # Database path logging for debugging
 try:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, Response, FileResponse
 from fastapi.exceptions import RequestValidationError
@@ -94,12 +95,16 @@ async def http_exception_handler(_: Request, exc: StarletteHTTPException):
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(_: Request, exc: RequestValidationError):
     logger.error(f"Validation error: {exc.errors()}")
+    validation_errors = jsonable_encoder(
+        exc.errors(),
+        custom_encoder={ValueError: str},
+    )
     return JSONResponse(
         status_code=422,
         content={
             "error": True,
             "message": "Request validation failed",
-            "details": exc.errors() if settings.debug else None,
+            "details": validation_errors if settings.debug else None,
         },
     )
 

--- a/backend/app/migrations/add_flywheel_attribution.py
+++ b/backend/app/migrations/add_flywheel_attribution.py
@@ -23,6 +23,7 @@ def run_migration(engine: Engine) -> list[str]:
     if "chat_history" in tables:
         chat_columns = {
             "config_id": "INTEGER",
+            "experiment_id": "INTEGER",
             "model_name": "VARCHAR(100)",
             "latency_ms": "INTEGER",
         }
@@ -34,6 +35,7 @@ def run_migration(engine: Engine) -> list[str]:
         feedback_columns = {
             "response_id": "INTEGER",
             "config_id": "INTEGER",
+            "experiment_id": "INTEGER",
         }
         for name, definition in feedback_columns.items():
             if _add_column(engine, "feedback", name, definition):
@@ -56,6 +58,18 @@ def run_migration(engine: Engine) -> list[str]:
             text(
                 "CREATE INDEX IF NOT EXISTS "
                 "ix_feedback_config_id ON feedback (config_id)"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS "
+                "ix_chat_history_experiment_id ON chat_history (experiment_id)"
+            )
+        )
+        connection.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS "
+                "ix_feedback_experiment_id ON feedback (experiment_id)"
             )
         )
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -42,6 +42,13 @@ class Feedback(Base):
         index=True,
         comment="Configuration attributed to the rated response",
     )
+    experiment_id = Column(
+        Integer,
+        ForeignKey("experiments.id"),
+        nullable=True,
+        index=True,
+        comment="Experiment attributed to the rated response",
+    )
     timestamp = Column(DateTime(timezone=True), server_default=func.now(), comment="Feedback submission time")
 
     def __repr__(self) -> str:
@@ -75,6 +82,13 @@ class ChatHistory(Base):
         index=True,
         comment="Configuration used for this message",
     )
+    experiment_id = Column(
+        Integer,
+        ForeignKey("experiments.id"),
+        nullable=True,
+        index=True,
+        comment="A/B experiment used for this message",
+    )
     model_name = Column(String(100), nullable=True, comment="Model used for assistant responses")
     latency_ms = Column(Integer, nullable=True, comment="Assistant response latency in milliseconds")
 
@@ -107,6 +121,41 @@ class ChatbotConfig(Base):
 
     def __repr__(self) -> str:
         return f"<ChatbotConfig(id={self.id}, name={self.name}, is_active={self.is_active})>"
+
+
+class Experiment(Base):
+    """Weighted A/B experiment over two or more chatbot configurations."""
+
+    __tablename__ = "experiments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), nullable=False, unique=True, comment="Experiment name")
+    status = Column(
+        String(20),
+        nullable=False,
+        default="draft",
+        index=True,
+        comment="draft, active, paused, or completed",
+    )
+    variants = Column(
+        JSON,
+        nullable=False,
+        comment="Weighted variants: [{config_id, weight}]",
+    )
+    created_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        comment="Experiment creation time",
+    )
+    updated_at = Column(
+        DateTime,
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        comment="Last update timestamp",
+    )
+
+    def __repr__(self) -> str:
+        return f"<Experiment(id={self.id}, name={self.name}, status={self.status})>"
 
 
 class KnowledgeFile(Base):

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -230,8 +230,13 @@ async def chat_with_bot(
             )
 
         local_settings = get_settings()
+        is_new_session = request.session_id is None
         session_id = request.session_id or str(uuid.uuid4())
-        config, experiment = select_chat_configuration(db, session_id)
+        config, experiment = select_chat_configuration(
+            db,
+            session_id,
+            is_new_session=is_new_session,
+        )
 
         lower_message = sanitized_message.lower()
         time_triggers = (

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -23,6 +23,7 @@ from .models import ChatHistory, Feedback, ChatbotConfig
 from .schemas import ChatRequest, FeedbackCreate, ChatbotConfigCreate, ChatbotConfigOut
 from .knowledge_processor import KnowledgeProcessor
 from .auth import verify_bearer_token
+from .experiments import select_chat_configuration
 from .services.llm import llm, chat
 
 # Initialize settings and logging
@@ -83,6 +84,7 @@ async def submit_feedback(request: FeedbackCreate, db: Session = Depends(get_db)
 
         response = None
         config_id = None
+        experiment_id = None
         if request.response_id is not None:
             response = (
                 db.query(ChatHistory)
@@ -98,6 +100,7 @@ async def submit_feedback(request: FeedbackCreate, db: Session = Depends(get_db)
                     detail="Assistant response not found",
                 )
             config_id = response.config_id
+            experiment_id = response.experiment_id
 
         feedback = Feedback(
             message=sanitized_message,
@@ -105,6 +108,7 @@ async def submit_feedback(request: FeedbackCreate, db: Session = Depends(get_db)
             comment=sanitized_comment,
             response_id=request.response_id,
             config_id=config_id,
+            experiment_id=experiment_id,
         )
 
         db.add(feedback)
@@ -166,6 +170,7 @@ async def get_feedback(
                 "comment": f.comment,
                 "response_id": f.response_id,
                 "config_id": f.config_id,
+                "experiment_id": f.experiment_id,
                 "timestamp": f.timestamp.isoformat()
             }
             for f in feedback_entries
@@ -225,12 +230,8 @@ async def chat_with_bot(
             )
 
         local_settings = get_settings()
-        config = (
-            db.query(ChatbotConfig)
-            .filter(ChatbotConfig.is_active.is_(True))
-            .order_by(ChatbotConfig.updated_at.desc())
-            .first()
-        )
+        session_id = request.session_id or str(uuid.uuid4())
+        config, experiment = select_chat_configuration(db, session_id)
 
         lower_message = sanitized_message.lower()
         time_triggers = (
@@ -241,13 +242,13 @@ async def chat_with_bot(
             "tell me the time",
         )
         if any(trigger in lower_message for trigger in time_triggers):
-            session_id = request.session_id or str(uuid.uuid4())
             user_chat = ChatHistory(
                 session_id=session_id,
                 role="user",
                 content=sanitized_message,
                 user_id=request.user_id,
                 config_id=config.id if config else None,
+                experiment_id=experiment.id if experiment else None,
             )
             db.add(user_chat)
             db.commit()
@@ -261,6 +262,7 @@ async def chat_with_bot(
                 role="assistant",
                 content=reply_text,
                 config_id=config.id if config else None,
+                experiment_id=experiment.id if experiment else None,
                 model_name="system-clock",
                 latency_ms=0,
             )
@@ -277,6 +279,8 @@ async def chat_with_bot(
                         "session_id": user_chat.session_id,
                         "assistant_message_id": assistant_chat.id,
                         "config_id": config.id if config else None,
+                        "experiment_id": experiment.id if experiment else None,
+                        "experiment_name": experiment.name if experiment else None,
                         "model": "system-clock",
                     }
                     yield f"data: {json.dumps(payload)}\n\n"
@@ -297,6 +301,8 @@ async def chat_with_bot(
                 "session_id": user_chat.session_id,
                 "assistant_message_id": assistant_chat.id,
                 "config_id": config.id if config else None,
+                "experiment_id": experiment.id if experiment else None,
+                "experiment_name": experiment.name if experiment else None,
                 "model": "system-clock",
             }
 
@@ -356,11 +362,12 @@ async def chat_with_bot(
 
         # Save user message to database
         user_chat = ChatHistory(
-            session_id=request.session_id or str(uuid.uuid4()),
+            session_id=session_id,
             role='user',
             content=sanitized_message,
             user_id=request.user_id,
             config_id=config.id if config else None,
+            experiment_id=experiment.id if experiment else None,
         )
         db.add(user_chat)
         db.commit()  # Commit user message before streaming to prevent data loss
@@ -374,6 +381,8 @@ async def chat_with_bot(
                     "reply": "",
                     "session_id": user_chat.session_id,
                     "config_id": config.id if config else None,
+                    "experiment_id": experiment.id if experiment else None,
+                    "experiment_name": experiment.name if experiment else None,
                     "model": model,
                 }
                 start_time = time.time()
@@ -414,6 +423,7 @@ async def chat_with_bot(
                                     role='assistant',
                                     content=full_response,
                                     config_id=config.id if config else None,
+                                    experiment_id=experiment.id if experiment else None,
                                     model_name=model,
                                     latency_ms=int((time.time() - start_time) * 1000),
                                 )
@@ -496,6 +506,7 @@ async def chat_with_bot(
             role='assistant',
             content=reply,
             config_id=config.id if config else None,
+            experiment_id=experiment.id if experiment else None,
             model_name=model,
             latency_ms=llm_response.get(
                 "latency_ms",
@@ -512,6 +523,8 @@ async def chat_with_bot(
             "session_id": user_chat.session_id,
             "assistant_message_id": assistant_chat.id,
             "config_id": config.id if config else None,
+            "experiment_id": experiment.id if experiment else None,
+            "experiment_name": experiment.name if experiment else None,
             "model": model,
         }
 

--- a/backend/app/routes_analytics.py
+++ b/backend/app/routes_analytics.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from .auth import verify_bearer_token
 from .db import SessionLocal
-from .models import ChatHistory, ChatbotConfig, Feedback
+from .models import ChatHistory, ChatbotConfig, Experiment, Feedback
 
 router = APIRouter(prefix="/analytics", tags=["flywheel-analytics"])
 
@@ -19,6 +19,110 @@ def get_db():
         yield db
     finally:
         db.close()
+
+
+@router.get("/experiments")
+async def experiment_performance(
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    """Return experiment lifecycle and outcome metrics by variant."""
+    experiments = db.query(Experiment).order_by(Experiment.updated_at.desc()).all()
+    configs = {config.id: config for config in db.query(ChatbotConfig).all()}
+
+    response_rows = (
+        db.query(
+            ChatHistory.experiment_id,
+            ChatHistory.config_id,
+            func.count(ChatHistory.id).label("total_responses"),
+            func.count(func.distinct(ChatHistory.session_id)).label("sessions"),
+            func.avg(ChatHistory.latency_ms).label("average_latency_ms"),
+        )
+        .filter(
+            ChatHistory.role == "assistant",
+            ChatHistory.experiment_id.is_not(None),
+        )
+        .group_by(ChatHistory.experiment_id, ChatHistory.config_id)
+        .all()
+    )
+    feedback_rows = (
+        db.query(
+            Feedback.experiment_id,
+            Feedback.config_id,
+            func.count(Feedback.id).label("rated_responses"),
+            func.sum(
+                case((Feedback.user_feedback == "thumbs_up", 1), else_=0)
+            ).label("positive_feedback"),
+            func.sum(
+                case((Feedback.user_feedback == "thumbs_down", 1), else_=0)
+            ).label("negative_feedback"),
+        )
+        .filter(Feedback.experiment_id.is_not(None))
+        .group_by(Feedback.experiment_id, Feedback.config_id)
+        .all()
+    )
+
+    responses = {
+        (row.experiment_id, row.config_id): row for row in response_rows
+    }
+    feedback = {
+        (row.experiment_id, row.config_id): row for row in feedback_rows
+    }
+    results = []
+    for experiment in experiments:
+        variants = []
+        for configured_variant in experiment.variants:
+            config_id = int(configured_variant["config_id"])
+            response = responses.get((experiment.id, config_id))
+            rating = feedback.get((experiment.id, config_id))
+            total = int(response.total_responses or 0) if response else 0
+            sessions = int(response.sessions or 0) if response else 0
+            rated = int(rating.rated_responses or 0) if rating else 0
+            positive = int(rating.positive_feedback or 0) if rating else 0
+            variants.append(
+                {
+                    "config_id": config_id,
+                    "config_name": (
+                        configs[config_id].name
+                        if config_id in configs
+                        else f"Config {config_id}"
+                    ),
+                    "weight": int(configured_variant["weight"]),
+                    "sessions": sessions,
+                    "total_responses": total,
+                    "rated_responses": rated,
+                    "positive_feedback": positive,
+                    "negative_feedback": (
+                        int(rating.negative_feedback or 0) if rating else 0
+                    ),
+                    "approval_rate": round(positive / rated, 4) if rated else None,
+                    "feedback_coverage": round(rated / total, 4) if total else 0,
+                    "average_latency_ms": (
+                        round(float(response.average_latency_ms), 1)
+                        if response and response.average_latency_ms is not None
+                        else None
+                    ),
+                }
+            )
+        total_sessions = sum(variant["sessions"] for variant in variants)
+        for variant in variants:
+            variant["actual_allocation"] = (
+                round(variant["sessions"] / total_sessions, 4)
+                if total_sessions
+                else 0
+            )
+        results.append(
+            {
+                "experiment_id": experiment.id,
+                "name": experiment.name,
+                "status": experiment.status,
+                "total_sessions": total_sessions,
+                "variants": variants,
+                "created_at": experiment.created_at.isoformat(),
+                "updated_at": experiment.updated_at.isoformat(),
+            }
+        )
+    return results
 
 
 @router.get("/configurations")
@@ -158,6 +262,7 @@ async def negative_feedback_examples(
                 "comment": feedback.comment,
                 "config_id": feedback.config_id,
                 "config_name": config.name if config else "Unattributed",
+                "experiment_id": feedback.experiment_id,
                 "model": response.model_name if response else None,
                 "timestamp": feedback.timestamp.isoformat(),
             }

--- a/backend/app/routes_configs.py
+++ b/backend/app/routes_configs.py
@@ -7,7 +7,6 @@ under the /api/v1/configs path.
 
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import desc
@@ -94,7 +93,10 @@ async def list_configs(
         pages = ceil(total / size) if total > 0 else 1
 
         response_data = {
-            "items": [ChatbotConfigOut.from_orm(config).dict() for config in configs],
+            "items": [
+                ChatbotConfigOut.model_validate(config).model_dump(mode="json")
+                for config in configs
+            ],
             "total": total,
             "page": page,
             "size": size,
@@ -102,7 +104,7 @@ async def list_configs(
         }
 
         logger.info(f"Retrieved {len(configs)} configs (total: {total})")
-        return JSONResponse(content=response_data)
+        return response_data
 
     except SQLAlchemyError as e:
         logger.error(f"Database error while listing configs: {str(e)}")

--- a/backend/app/routes_experiments.py
+++ b/backend/app/routes_experiments.py
@@ -1,0 +1,129 @@
+"""CRUD and lifecycle routes for weighted configuration experiments."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from .auth import verify_bearer_token
+from .db import SessionLocal
+from .experiments import validate_experiment_configs
+from .models import Experiment
+from .schemas import ExperimentCreate, ExperimentOut, ExperimentUpdate
+
+router = APIRouter(prefix="/experiments", tags=["configuration-experiments"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _experiment_or_404(db: Session, experiment_id: int) -> Experiment:
+    experiment = db.query(Experiment).filter(Experiment.id == experiment_id).first()
+    if not experiment:
+        raise HTTPException(status_code=404, detail="Experiment not found")
+    return experiment
+
+
+@router.get("", response_model=list[ExperimentOut])
+async def list_experiments(
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    return db.query(Experiment).order_by(Experiment.updated_at.desc()).all()
+
+
+@router.post("", response_model=ExperimentOut, status_code=status.HTTP_201_CREATED)
+async def create_experiment(
+    request: ExperimentCreate,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    variants = [variant.model_dump() for variant in request.variants]
+    validate_experiment_configs(db, variants)
+    if db.query(Experiment).filter(Experiment.name == request.name).first():
+        raise HTTPException(status_code=400, detail="Experiment name already exists")
+    experiment = Experiment(name=request.name, variants=variants, status="draft")
+    db.add(experiment)
+    db.commit()
+    db.refresh(experiment)
+    return experiment
+
+
+@router.put("/{experiment_id}", response_model=ExperimentOut)
+async def update_experiment(
+    experiment_id: int,
+    request: ExperimentUpdate,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    experiment = _experiment_or_404(db, experiment_id)
+    if experiment.status == "active":
+        raise HTTPException(status_code=409, detail="Pause the experiment before editing it")
+    if request.name is not None:
+        duplicate = (
+            db.query(Experiment)
+            .filter(Experiment.name == request.name, Experiment.id != experiment_id)
+            .first()
+        )
+        if duplicate:
+            raise HTTPException(status_code=400, detail="Experiment name already exists")
+        experiment.name = request.name
+    if request.variants is not None:
+        variants = [variant.model_dump() for variant in request.variants]
+        validate_experiment_configs(db, variants)
+        experiment.variants = variants
+    db.commit()
+    db.refresh(experiment)
+    return experiment
+
+
+@router.post("/{experiment_id}/activate", response_model=ExperimentOut)
+async def activate_experiment(
+    experiment_id: int,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    try:
+        experiment = _experiment_or_404(db, experiment_id)
+        validate_experiment_configs(db, experiment.variants)
+        db.query(Experiment).filter(
+            Experiment.status == "active",
+            Experiment.id != experiment_id,
+        ).update({"status": "paused"}, synchronize_session=False)
+        experiment.status = "active"
+        db.commit()
+        db.refresh(experiment)
+        return experiment
+    except SQLAlchemyError:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="Failed to activate experiment")
+
+
+@router.post("/{experiment_id}/pause", response_model=ExperimentOut)
+async def pause_experiment(
+    experiment_id: int,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    experiment = _experiment_or_404(db, experiment_id)
+    experiment.status = "paused"
+    db.commit()
+    db.refresh(experiment)
+    return experiment
+
+
+@router.post("/{experiment_id}/complete", response_model=ExperimentOut)
+async def complete_experiment(
+    experiment_id: int,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    experiment = _experiment_or_404(db, experiment_id)
+    experiment.status = "completed"
+    db.commit()
+    db.refresh(experiment)
+    return experiment

--- a/backend/app/routes_experiments.py
+++ b/backend/app/routes_experiments.py
@@ -109,11 +109,15 @@ async def pause_experiment(
     db: Session = Depends(get_db),
     _: None = Depends(verify_bearer_token),
 ):
-    experiment = _experiment_or_404(db, experiment_id)
-    experiment.status = "paused"
-    db.commit()
-    db.refresh(experiment)
-    return experiment
+    try:
+        experiment = _experiment_or_404(db, experiment_id)
+        experiment.status = "paused"
+        db.commit()
+        db.refresh(experiment)
+        return experiment
+    except SQLAlchemyError:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="Failed to pause experiment")
 
 
 @router.post("/{experiment_id}/complete", response_model=ExperimentOut)
@@ -122,8 +126,12 @@ async def complete_experiment(
     db: Session = Depends(get_db),
     _: None = Depends(verify_bearer_token),
 ):
-    experiment = _experiment_or_404(db, experiment_id)
-    experiment.status = "completed"
-    db.commit()
-    db.refresh(experiment)
-    return experiment
+    try:
+        experiment = _experiment_or_404(db, experiment_id)
+        experiment.status = "completed"
+        db.commit()
+        db.refresh(experiment)
+        return experiment
+    except SQLAlchemyError:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="Failed to complete experiment")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -107,6 +107,66 @@ class FeedbackCreate(BaseModel):
     )
 
 
+class ExperimentStatus(str, Enum):
+    """Lifecycle state for a configuration experiment."""
+
+    draft = "draft"
+    active = "active"
+    paused = "paused"
+    completed = "completed"
+
+
+class ExperimentVariant(BaseModel):
+    """One weighted configuration variant."""
+
+    config_id: int = Field(..., ge=1)
+    weight: int = Field(..., ge=1, le=99)
+
+
+class ExperimentCreate(BaseModel):
+    """Create a weighted A/B configuration experiment."""
+
+    name: str = Field(..., min_length=1, max_length=100)
+    variants: List[ExperimentVariant] = Field(..., min_length=2)
+
+    @field_validator("variants")
+    @classmethod
+    def validate_variants(cls, variants):
+        config_ids = [variant.config_id for variant in variants]
+        if len(config_ids) != len(set(config_ids)):
+            raise ValueError("Each configuration can appear only once")
+        if sum(variant.weight for variant in variants) != 100:
+            raise ValueError("Variant weights must total 100")
+        return variants
+
+
+class ExperimentUpdate(BaseModel):
+    """Update experiment metadata or weighted variants."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    variants: Optional[List[ExperimentVariant]] = Field(None, min_length=2)
+
+    @field_validator("variants")
+    @classmethod
+    def validate_variants(cls, variants):
+        if variants is None:
+            return variants
+        return ExperimentCreate(name="validation", variants=variants).variants
+
+
+class ExperimentOut(BaseModel):
+    """Experiment API response."""
+
+    id: int
+    name: str
+    status: ExperimentStatus
+    variants: List[ExperimentVariant]
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
 class ChatbotConfigBase(BaseModel):
     """
     Base schema for chatbot configuration.

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -222,7 +222,10 @@ class ChatbotConfigBase(BaseModel):
         for field in required_fields:
             if field not in v:
                 raise ValueError(f'Missing required field: {field}')
-        if not 0 <= v.get('temperature', 0.7) <= 2:
+        temperature = v.get('temperature')
+        if isinstance(temperature, bool) or not isinstance(temperature, (int, float)):
+            raise ValueError('Temperature must be a number between 0 and 2')
+        if not 0 <= temperature <= 2:
             raise ValueError('Temperature must be between 0 and 2')
         if not str(v.get('system_prompt', '')).strip():
             raise ValueError('system_prompt cannot be empty')
@@ -263,8 +266,12 @@ class ChatbotConfigUpdate(BaseModel):
         """Validate configuration fields if provided."""
         if v is None:
             return v
-        if 'temperature' in v and not 0 <= v['temperature'] <= 2:
-            raise ValueError('Temperature must be between 0 and 2')
+        if 'temperature' in v:
+            temperature = v['temperature']
+            if isinstance(temperature, bool) or not isinstance(temperature, (int, float)):
+                raise ValueError('Temperature must be a number between 0 and 2')
+            if not 0 <= temperature <= 2:
+                raise ValueError('Temperature must be between 0 and 2')
         if 'system_prompt' in v and not str(v['system_prompt']).strip():
             raise ValueError('system_prompt cannot be empty')
         if 'model' in v and not str(v['model']).strip():

--- a/backend/tests/test_ab_experiments.py
+++ b/backend/tests/test_ab_experiments.py
@@ -1,0 +1,176 @@
+"""Integration tests for weighted, sticky configuration experiments."""
+
+from app.db import SessionLocal
+from app.experiments import choose_weighted_variant
+from app.models import ChatbotConfig, Experiment
+
+
+def _add_variant(name: str, prompt: str) -> int:
+    db = SessionLocal()
+    try:
+        config = ChatbotConfig(
+            name=name,
+            config_json={
+                "system_prompt": prompt,
+                "model": "gpt-4o",
+                "temperature": 0.2,
+            },
+            is_active=True,
+        )
+        db.add(config)
+        db.commit()
+        db.refresh(config)
+        return config.id
+    finally:
+        db.close()
+
+
+def _create_active_experiment(test_client, variants, name="Prompt comparison"):
+    created = test_client.post(
+        "/api/v1/experiments",
+        json={"name": name, "variants": variants},
+    )
+    assert created.status_code == 201, created.text
+    experiment_id = created.json()["id"]
+    activated = test_client.post(f"/api/v1/experiments/{experiment_id}/activate")
+    assert activated.status_code == 200, activated.text
+    return activated.json()
+
+
+def test_active_experiment_routes_new_session_and_sticks(test_client, mock_llm):
+    concise_id = _add_variant("Concise", "Answer concisely.")
+    detailed_id = _add_variant("Detailed", "Answer with detail.")
+    experiment = _create_active_experiment(
+        test_client,
+        [
+            {"config_id": concise_id, "weight": 50},
+            {"config_id": detailed_id, "weight": 50},
+        ],
+    )
+
+    first = test_client.post(
+        "/api/v1/chat",
+        json={"message": "First turn"},
+    ).json()
+    second = test_client.post(
+        "/api/v1/chat",
+        json={"message": "Second turn", "session_id": first["session_id"]},
+    ).json()
+
+    assert first["experiment_id"] == experiment["id"]
+    assert first["experiment_name"] == experiment["name"]
+    assert first["config_id"] in {concise_id, detailed_id}
+    assert second["config_id"] == first["config_id"]
+    assert second["experiment_id"] == first["experiment_id"]
+
+
+def test_weighted_assignment_is_deterministic_and_tracks_target_split():
+    experiment = Experiment(
+        id=42,
+        name="Weighted",
+        status="active",
+        variants=[
+            {"config_id": 10, "weight": 70},
+            {"config_id": 20, "weight": 30},
+        ],
+    )
+
+    first = choose_weighted_variant(experiment, "same-session")
+    assert choose_weighted_variant(experiment, "same-session") == first
+
+    assignments = [
+        choose_weighted_variant(experiment, f"session-{index}")
+        for index in range(1000)
+    ]
+    first_share = assignments.count(10) / len(assignments)
+    assert 0.65 <= first_share <= 0.75
+
+
+def test_activating_experiment_pauses_previous_experiment(test_client):
+    first_id = _add_variant("First A", "First A")
+    second_id = _add_variant("First B", "First B")
+    third_id = _add_variant("Second A", "Second A")
+    fourth_id = _add_variant("Second B", "Second B")
+
+    first = _create_active_experiment(
+        test_client,
+        [
+            {"config_id": first_id, "weight": 50},
+            {"config_id": second_id, "weight": 50},
+        ],
+        name="First experiment",
+    )
+    second = _create_active_experiment(
+        test_client,
+        [
+            {"config_id": third_id, "weight": 50},
+            {"config_id": fourth_id, "weight": 50},
+        ],
+        name="Second experiment",
+    )
+
+    experiments = test_client.get("/api/v1/experiments").json()
+    states = {experiment["id"]: experiment["status"] for experiment in experiments}
+    assert states[first["id"]] == "paused"
+    assert states[second["id"]] == "active"
+
+
+def test_experiment_analytics_include_attributed_feedback(test_client, mock_llm):
+    variant_a = _add_variant("Variant A", "Use approach A.")
+    variant_b = _add_variant("Variant B", "Use approach B.")
+    experiment = _create_active_experiment(
+        test_client,
+        [
+            {"config_id": variant_a, "weight": 50},
+            {"config_id": variant_b, "weight": 50},
+        ],
+    )
+    chat = test_client.post(
+        "/api/v1/chat",
+        json={"message": "Evaluate this experiment"},
+    ).json()
+    feedback = test_client.post(
+        "/api/v1/feedback",
+        json={
+            "message": chat["reply"],
+            "response_id": chat["assistant_message_id"],
+            "user_feedback": "thumbs_up",
+        },
+    )
+    assert feedback.status_code == 201
+
+    analytics = test_client.get("/api/v1/analytics/experiments")
+    assert analytics.status_code == 200
+    result = analytics.json()[0]
+    assert result["experiment_id"] == experiment["id"]
+    attributed = next(
+        variant
+        for variant in result["variants"]
+        if variant["config_id"] == chat["config_id"]
+    )
+    assert attributed["sessions"] == 1
+    assert attributed["rated_responses"] == 1
+    assert attributed["approval_rate"] == 1.0
+
+
+def test_experiment_rejects_invalid_or_inactive_variants(test_client):
+    active_id = _add_variant("Active variant", "Active")
+    response = test_client.post(
+        "/api/v1/experiments",
+        json={
+            "name": "Invalid experiment",
+            "variants": [
+                {"config_id": active_id, "weight": 50},
+                {"config_id": 999999, "weight": 50},
+            ],
+        },
+    )
+    assert response.status_code == 400
+
+
+def test_active_configuration_list_is_json_serializable(test_client):
+    response = test_client.get("/api/v1/configs?active_only=true&size=100")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] >= 1
+    assert data["items"][0]["created_at"]

--- a/backend/tests/test_ab_experiments.py
+++ b/backend/tests/test_ab_experiments.py
@@ -1,5 +1,8 @@
 """Integration tests for weighted, sticky configuration experiments."""
 
+from sqlalchemy import event
+
+from app.db import engine
 from app.db import SessionLocal
 from app.experiments import choose_weighted_variant
 from app.models import ChatbotConfig, Experiment
@@ -174,3 +177,46 @@ def test_active_configuration_list_is_json_serializable(test_client):
     data = response.json()
     assert data["total"] >= 1
     assert data["items"][0]["created_at"]
+
+
+def test_new_session_skips_sticky_assignment_history_query(test_client, mock_llm):
+    sticky_assignment_queries = []
+
+    def capture_select(_conn, _cursor, statement, _parameters, _context, _many):
+        normalized = " ".join(statement.lower().split())
+        if (
+            normalized.startswith("select")
+            and "from chat_history" in normalized
+            and "chat_history.session_id =" in normalized
+            and "chat_history.config_id is not null" in normalized
+        ):
+            sticky_assignment_queries.append(normalized)
+
+    event.listen(engine, "before_cursor_execute", capture_select)
+    try:
+        response = test_client.post(
+            "/api/v1/chat",
+            json={"message": "Start a new routed session"},
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", capture_select)
+
+    assert response.status_code == 200
+    assert sticky_assignment_queries == []
+
+
+def test_config_creation_rejects_non_numeric_temperature(test_client):
+    response = test_client.post(
+        "/api/v1/configs",
+        json={
+            "name": "Invalid temperature",
+            "config_json": {
+                "system_prompt": "Be helpful.",
+                "model": "gpt-4o",
+                "temperature": None,
+            },
+            "is_active": True,
+        },
+    )
+
+    assert response.status_code == 422

--- a/backend/tests/test_flywheel_analytics.py
+++ b/backend/tests/test_flywheel_analytics.py
@@ -184,11 +184,12 @@ def test_attribution_migration_upgrades_existing_database(tmp_path):
     assert "feedback.response_id" in applied
     assert {
         "config_id",
+        "experiment_id",
         "model_name",
         "latency_ms",
     }.issubset(
         {column["name"] for column in inspect(engine).get_columns("chat_history")}
     )
-    assert {"response_id", "config_id"}.issubset(
+    assert {"response_id", "config_id", "experiment_id"}.issubset(
         {column["name"] for column in inspect(engine).get_columns("feedback")}
     )

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -910,7 +910,7 @@ async function createConfiguration(event) {
         );
         return;
     }
-    if (temperature < 0 || temperature > 2) {
+    if (Number.isNaN(temperature) || temperature < 0 || temperature > 2) {
         showAnalyticsStatus('Temperature must be between 0 and 2.', 'error');
         return;
     }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -40,7 +40,7 @@ const api = {
         const response = await fetch(`${this.baseUrl}${path}`, {
             method: 'POST',
             headers: this.buildHeaders(true),
-            body: JSON.stringify(body)
+            body: JSON.stringify(body ?? {})
         });
         return this.handleResponse(response);
     },
@@ -104,12 +104,29 @@ const elements = {
     totalResponsesMetric: document.getElementById('totalResponsesMetric'),
     ratedResponsesMetric: document.getElementById('ratedResponsesMetric'),
     approvalRateMetric: document.getElementById('approvalRateMetric'),
-    feedbackCoverageMetric: document.getElementById('feedbackCoverageMetric')
+    feedbackCoverageMetric: document.getElementById('feedbackCoverageMetric'),
+    configurationForm: document.getElementById('configurationForm'),
+    configurationName: document.getElementById('configurationName'),
+    configurationModel: document.getElementById('configurationModel'),
+    configurationTemperature: document.getElementById('configurationTemperature'),
+    configurationPrompt: document.getElementById('configurationPrompt'),
+    createConfigurationBtn: document.getElementById('createConfigurationBtn'),
+    experimentForm: document.getElementById('experimentForm'),
+    experimentName: document.getElementById('experimentName'),
+    variantAConfig: document.getElementById('variantAConfig'),
+    variantAWeight: document.getElementById('variantAWeight'),
+    variantBConfig: document.getElementById('variantBConfig'),
+    variantBWeight: document.getElementById('variantBWeight'),
+    createExperimentBtn: document.getElementById('createExperimentBtn'),
+    experimentList: document.getElementById('experimentList')
 };
 
 // Application state
 let currentFeedbackMessageId = null;
 let currentSessionId = null;
+let activeConfigs = [];
+let experimentDefinitions = [];
+let experimentMetrics = [];
 
 // Utility functions
 function showStatus(message, type = 'success') {
@@ -781,17 +798,227 @@ function renderSummaryMetrics(configurations) {
         : '0%';
 }
 
+function renderExperimentConfigOptions(configs) {
+    const currentA = elements.variantAConfig.value;
+    const currentB = elements.variantBConfig.value;
+    const options = configs.map(config =>
+        `<option value="${config.id}">${escapeHtml(config.name)}</option>`
+    ).join('');
+    elements.variantAConfig.innerHTML = options ||
+        '<option value="">Create two active configurations first</option>';
+    elements.variantBConfig.innerHTML = options ||
+        '<option value="">Create two active configurations first</option>';
+
+    if (configs.some(config => String(config.id) === currentA)) {
+        elements.variantAConfig.value = currentA;
+    }
+    if (configs.some(config => String(config.id) === currentB)) {
+        elements.variantBConfig.value = currentB;
+    } else if (configs.length > 1) {
+        elements.variantBConfig.value = String(configs[1].id);
+    }
+    if (
+        configs.length > 1 &&
+        elements.variantBConfig.value === elements.variantAConfig.value
+    ) {
+        const alternative = configs.find(
+            config => String(config.id) !== elements.variantAConfig.value
+        );
+        elements.variantBConfig.value = String(alternative.id);
+    }
+    elements.createExperimentBtn.disabled = configs.length < 2;
+}
+
+function renderExperiments() {
+    if (!experimentDefinitions.length) {
+        elements.experimentList.innerHTML =
+            '<div class="dashboard-empty">No experiments yet. Create a draft above.</div>';
+        return;
+    }
+
+    const metricsById = new Map(
+        experimentMetrics.map(metric => [metric.experiment_id, metric])
+    );
+    elements.experimentList.innerHTML = experimentDefinitions.map(experiment => {
+        const metrics = metricsById.get(experiment.id);
+        const variants = metrics?.variants || experiment.variants.map(variant => {
+            const config = activeConfigs.find(item => item.id === variant.config_id);
+            return {
+                ...variant,
+                config_name: config?.name || `Config ${variant.config_id}`,
+                sessions: 0,
+                approval_rate: null,
+                feedback_coverage: 0,
+                actual_allocation: 0
+            };
+        });
+        const rows = variants.map(variant => `
+            <tr>
+                <td><strong>${escapeHtml(variant.config_name)}</strong></td>
+                <td>${variant.weight}%</td>
+                <td>${variant.sessions}</td>
+                <td>${formatPercent(variant.actual_allocation)}</td>
+                <td>${formatPercent(variant.approval_rate)}</td>
+                <td>${formatPercent(variant.feedback_coverage)}</td>
+            </tr>
+        `).join('');
+        const action = experiment.status === 'active'
+            ? `<button class="btn btn-small" data-experiment-action="pause" data-experiment-id="${experiment.id}">Pause</button>`
+            : experiment.status !== 'completed'
+                ? `<button class="btn btn-small" data-experiment-action="activate" data-experiment-id="${experiment.id}">Activate</button>`
+                : '';
+        return `
+            <article class="experiment-card">
+                <div class="experiment-card-header">
+                    <div>
+                        <strong>${escapeHtml(experiment.name)}</strong>
+                        <div>${metrics?.total_sessions || 0} assigned session(s)</div>
+                    </div>
+                    <div class="experiment-card-actions">
+                        <span class="experiment-badge ${experiment.status === 'active' ? 'active' : ''}">${escapeHtml(experiment.status)}</span>
+                        ${action}
+                    </div>
+                </div>
+                <table class="analytics-table">
+                    <thead>
+                        <tr>
+                            <th>Variant</th>
+                            <th>Target</th>
+                            <th>Sessions</th>
+                            <th>Actual</th>
+                            <th>Approval</th>
+                            <th>Coverage</th>
+                        </tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            </article>
+        `;
+    }).join('');
+}
+
+async function createConfiguration(event) {
+    event.preventDefault();
+    const name = elements.configurationName.value.trim();
+    const model = elements.configurationModel.value.trim();
+    const systemPrompt = elements.configurationPrompt.value.trim();
+    const temperature = Number(elements.configurationTemperature.value);
+    if (!name || !model || !systemPrompt) {
+        showAnalyticsStatus(
+            'Configuration name, model, and system prompt are required.',
+            'error'
+        );
+        return;
+    }
+    if (temperature < 0 || temperature > 2) {
+        showAnalyticsStatus('Temperature must be between 0 and 2.', 'error');
+        return;
+    }
+
+    elements.createConfigurationBtn.disabled = true;
+    try {
+        await api.post('/configs', {
+            name,
+            config_json: {
+                system_prompt: systemPrompt,
+                model,
+                temperature
+            },
+            is_active: true,
+            tags: ['experiment']
+        });
+        elements.configurationName.value = '';
+        elements.configurationPrompt.value = '';
+        showAnalyticsStatus('Configuration added and ready for experiments.');
+        await loadAnalytics();
+    } catch (error) {
+        showAnalyticsStatus(`Configuration error: ${error.message}`, 'error');
+    } finally {
+        elements.createConfigurationBtn.disabled = false;
+    }
+}
+
+async function createExperiment(event) {
+    event.preventDefault();
+    const name = elements.experimentName.value.trim();
+    const configA = Number(elements.variantAConfig.value);
+    const configB = Number(elements.variantBConfig.value);
+    const weightA = Number(elements.variantAWeight.value);
+    const weightB = Number(elements.variantBWeight.value);
+
+    if (!name || !configA || !configB) {
+        showAnalyticsStatus('Enter a name and select two configurations.', 'error');
+        return;
+    }
+    if (configA === configB) {
+        showAnalyticsStatus('Variant A and B must use different configurations.', 'error');
+        return;
+    }
+    if (weightA + weightB !== 100) {
+        showAnalyticsStatus('Variant weights must total 100%.', 'error');
+        return;
+    }
+
+    elements.createExperimentBtn.disabled = true;
+    try {
+        await api.post('/experiments', {
+            name,
+            variants: [
+                {config_id: configA, weight: weightA},
+                {config_id: configB, weight: weightB}
+            ]
+        });
+        elements.experimentName.value = '';
+        showAnalyticsStatus('Experiment draft created.');
+        await loadAnalytics();
+    } catch (error) {
+        showAnalyticsStatus(`Experiment error: ${error.message}`, 'error');
+    } finally {
+        elements.createExperimentBtn.disabled = activeConfigs.length < 2;
+    }
+}
+
+async function handleExperimentAction(event) {
+    const button = event.target.closest('[data-experiment-action]');
+    if (!button) {
+        return;
+    }
+    const experimentId = button.dataset.experimentId;
+    const action = button.dataset.experimentAction;
+    button.disabled = true;
+    try {
+        await api.post(`/experiments/${experimentId}/${action}`);
+        showAnalyticsStatus(
+            action === 'activate'
+                ? 'Experiment activated for new sessions.'
+                : 'Experiment paused. Existing sessions remain attributed.'
+        );
+        await loadAnalytics();
+    } catch (error) {
+        showAnalyticsStatus(`Experiment error: ${error.message}`, 'error');
+        button.disabled = false;
+    }
+}
+
 async function loadAnalytics() {
     elements.refreshAnalyticsBtn.disabled = true;
     showAnalyticsStatus('Loading analytics...');
 
     try {
-        const [configurations, negativeFeedback] = await Promise.all([
+        const [configurations, negativeFeedback, experiments, experimentAnalytics, configs] = await Promise.all([
             api.get('/analytics/configurations'),
-            api.get('/analytics/negative-feedback?limit=20')
+            api.get('/analytics/negative-feedback?limit=20'),
+            api.get('/experiments'),
+            api.get('/analytics/experiments'),
+            api.get('/configs?active_only=true&size=100')
         ]);
 
+        activeConfigs = configs.items;
+        experimentDefinitions = experiments;
+        experimentMetrics = experimentAnalytics;
         renderSummaryMetrics(configurations);
+        renderExperimentConfigOptions(activeConfigs);
+        renderExperiments();
         renderConfigurationAnalytics(configurations);
         renderNegativeFeedback(negativeFeedback);
         showAnalyticsStatus(`Loaded ${configurations.length} configuration result(s).`);
@@ -835,6 +1062,9 @@ elements.chatViewBtn.addEventListener('click', () => setActiveView('chat'));
 elements.analyticsViewBtn.addEventListener('click', () => setActiveView('analytics'));
 elements.refreshAnalyticsBtn.addEventListener('click', loadAnalytics);
 elements.saveTokenBtn.addEventListener('click', saveAnalyticsToken);
+elements.configurationForm.addEventListener('submit', createConfiguration);
+elements.experimentForm.addEventListener('submit', createExperiment);
+elements.experimentList.addEventListener('click', handleExperimentAction);
 
 // Initialize
 console.log('Data Flywheel Chatbot initialized');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -429,6 +429,95 @@
             font-size: 13px;
         }
 
+        .experiment-builder {
+            display: grid;
+            grid-template-columns: 1.2fr 1fr 90px 1fr 90px auto;
+            gap: 10px;
+            align-items: end;
+            padding: 16px 18px;
+            background: #f8fafc;
+            border-bottom: 1px solid #e2e8f0;
+        }
+
+        .configuration-builder {
+            display: grid;
+            grid-template-columns: 1fr 0.8fr 100px 2fr auto;
+            gap: 10px;
+            align-items: end;
+            padding: 16px 18px;
+            border-bottom: 1px solid #e2e8f0;
+        }
+
+        .experiment-field {
+            display: grid;
+            gap: 5px;
+        }
+
+        .experiment-field label {
+            color: #64748b;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+        }
+
+        .experiment-field input,
+        .experiment-field select {
+            width: 100%;
+            padding: 9px 10px;
+            border: 1px solid #cbd5e1;
+            border-radius: 5px;
+            background: white;
+            color: #172033;
+        }
+
+        .experiment-list {
+            display: grid;
+            gap: 12px;
+            padding: 16px;
+        }
+
+        .experiment-card {
+            border: 1px solid #dbe4ef;
+            border-radius: 8px;
+            overflow: hidden;
+        }
+
+        .experiment-card-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+            align-items: center;
+            padding: 13px 14px;
+            background: #f8fafc;
+        }
+
+        .experiment-card-actions {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .experiment-badge {
+            padding: 4px 8px;
+            border-radius: 99px;
+            background: #e2e8f0;
+            color: #475569;
+            font-size: 11px;
+            font-weight: 750;
+            text-transform: uppercase;
+        }
+
+        .experiment-badge.active {
+            background: #dcfce7;
+            color: #166534;
+        }
+
+        .btn-small {
+            padding: 6px 9px;
+            font-size: 12px;
+        }
+
         .analytics-table {
             width: 100%;
             border-collapse: collapse;
@@ -531,6 +620,14 @@
             .dashboard-actions {
                 justify-content: flex-start;
             }
+
+            .experiment-builder {
+                grid-template-columns: repeat(2, minmax(160px, 1fr));
+            }
+
+            .configuration-builder {
+                grid-template-columns: repeat(2, minmax(160px, 1fr));
+            }
         }
 
         @media (max-width: 650px) {
@@ -563,6 +660,15 @@
 
             .dashboard-panel {
                 overflow-x: auto;
+            }
+
+            .experiment-builder {
+                grid-template-columns: 1fr;
+                min-width: 0;
+            }
+
+            .configuration-builder {
+                grid-template-columns: 1fr;
             }
         }
     </style>
@@ -650,6 +756,60 @@
                     <span class="metric-value" id="feedbackCoverageMetric">—</span>
                 </article>
             </div>
+
+            <section class="dashboard-panel">
+                <div class="panel-header">
+                    <div>
+                        <h2>A/B configuration experiments</h2>
+                        <p>Split new chat sessions between configurations. Each session remains on its assigned variant.</p>
+                    </div>
+                </div>
+                <form class="configuration-builder" id="configurationForm">
+                    <div class="experiment-field">
+                        <label for="configurationName">Configuration name</label>
+                        <input id="configurationName" maxlength="100" placeholder="Concise responder">
+                    </div>
+                    <div class="experiment-field">
+                        <label for="configurationModel">Model</label>
+                        <input id="configurationModel" value="gpt-4o">
+                    </div>
+                    <div class="experiment-field">
+                        <label for="configurationTemperature">Temperature</label>
+                        <input id="configurationTemperature" type="number" min="0" max="2" step="0.1" value="0.7">
+                    </div>
+                    <div class="experiment-field">
+                        <label for="configurationPrompt">System prompt</label>
+                        <input id="configurationPrompt" placeholder="Answer clearly and concisely.">
+                    </div>
+                    <button class="btn" id="createConfigurationBtn" type="submit">Add config</button>
+                </form>
+                <form class="experiment-builder" id="experimentForm">
+                    <div class="experiment-field">
+                        <label for="experimentName">Experiment name</label>
+                        <input id="experimentName" maxlength="100" placeholder="Concise vs detailed">
+                    </div>
+                    <div class="experiment-field">
+                        <label for="variantAConfig">Variant A</label>
+                        <select id="variantAConfig"></select>
+                    </div>
+                    <div class="experiment-field">
+                        <label for="variantAWeight">Weight %</label>
+                        <input id="variantAWeight" type="number" min="1" max="99" value="50">
+                    </div>
+                    <div class="experiment-field">
+                        <label for="variantBConfig">Variant B</label>
+                        <select id="variantBConfig"></select>
+                    </div>
+                    <div class="experiment-field">
+                        <label for="variantBWeight">Weight %</label>
+                        <input id="variantBWeight" type="number" min="1" max="99" value="50">
+                    </div>
+                    <button class="btn" id="createExperimentBtn" type="submit">Create draft</button>
+                </form>
+                <div class="experiment-list" id="experimentList">
+                    <div class="dashboard-empty">No experiments loaded.</div>
+                </div>
+            </section>
 
             <section class="dashboard-panel">
                 <div class="panel-header">

--- a/tests/test_frontend_integration.py
+++ b/tests/test_frontend_integration.py
@@ -44,11 +44,16 @@ class TestFrontendIntegration:
         assert 'id="configurationAnalytics"' in response.text
         assert 'id="negativeFeedbackList"' in response.text
         assert 'id="analyticsToken"' in response.text
+        assert 'id="configurationForm"' in response.text
+        assert 'id="experimentForm"' in response.text
+        assert 'id="experimentList"' in response.text
 
         script_response = test_client.get("/app.js")
         assert script_response.status_code == 200
         assert "window.location" in script_response.text
         assert "return `${origin}/api/v1`" in script_response.text
+        assert "createExperiment" in script_response.text
+        assert "handleExperimentAction" in script_response.text
 
     # API Accessibility Tests
 

--- a/tests/test_frontend_integration.py
+++ b/tests/test_frontend_integration.py
@@ -54,6 +54,7 @@ class TestFrontendIntegration:
         assert "return `${origin}/api/v1`" in script_response.text
         assert "createExperiment" in script_response.text
         assert "handleExperimentAction" in script_response.text
+        assert "Number.isNaN(temperature)" in script_response.text
 
     # API Accessibility Tests
 


### PR DESCRIPTION
## What changed

- Added explicit configuration experiments with draft, active, paused, and completed lifecycle states.
- Added deterministic weighted routing so new chat sessions are assigned according to configured traffic percentages.
- Kept assignments sticky across multi-turn sessions.
- Persisted experiment attribution on chat history and feedback records.
- Added experiment analytics for session allocation, response volume, approval rate, feedback coverage, and latency.
- Added dashboard controls to create configurations, create experiment drafts, activate or pause experiments, and review variant performance.
- Extended the additive database migration for experiment attribution.
- Added integration tests and updated documentation.

## Why

The existing flywheel dashboard could compare historical configuration performance, but all live traffic used the most recently updated active configuration. That prevented controlled comparison of prompts and models.

This change creates an explicit experimentation layer. Multiple active configurations no longer imply traffic splitting; routing changes only when an experiment is deliberately activated.

## Impact

- Existing behavior remains unchanged when no experiment is active.
- Only one experiment can be active at a time.
- Existing sessions retain their original configuration and attribution.
- New sessions receive deterministic weighted assignments without requiring cookies or a separate assignment table.

## Validation

- Full Docker test suite: 27 passed, 20 skipped.
- Browser-tested configuration creation, experiment creation, activation, routing attribution, analytics refresh, and pause controls.
- Verified desktop layout and a 390 px mobile viewport without page-level horizontal overflow.
