### PR TITLE
[codex] add feedback improvement recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
 - **Internal Dashboard**: Review configuration metrics and negative feedback examples directly in the web interface
 - **A/B Configuration Routing**: Run weighted experiments across prompt/model configurations with deterministic, session-sticky assignment
 - **Experiment Operations**: Create configurations, launch or pause experiments, and compare target allocation with observed quality metrics from the dashboard
+- **Feedback Clustering**: Group recurring negative feedback into explainable failure themes such as verbosity, accuracy, clarity, and relevance
+- **Human-Approved Improvements**: Review evidence-backed prompt recommendations and create inactive configuration drafts without changing live traffic
 - **Time Utility Endpoint**: Quickly fetch the current UTC timestamp via the lightweight `/current_time` endpoint
 - **RESTful API**: Clean, well-documented API endpoints with automatic OpenAPI documentation
 - **Error Handling & Logging**: Comprehensive error handling with structured logging
@@ -199,6 +201,10 @@ automatically.
 - `POST /api/v1/experiments` - Create a weighted experiment draft
 - `POST /api/v1/experiments/{id}/activate` - Route new sessions through an experiment
 - `POST /api/v1/experiments/{id}/pause` - Stop assigning new sessions while preserving attribution
+- `GET /api/v1/recommendations` - List feedback-derived prompt recommendations and their review status
+- `POST /api/v1/recommendations/generate` - Cluster recurring negative feedback and upsert pending recommendations
+- `POST /api/v1/recommendations/{id}/approve` - Create an inactive configuration draft after human approval
+- `POST /api/v1/recommendations/{id}/dismiss` - Dismiss a recommendation while preserving its evidence
 
 Analytics endpoints require `Authorization: Bearer <APP_TOKEN>` when
 `APP_TOKEN` is configured.

--- a/backend/app/init_db.py
+++ b/backend/app/init_db.py
@@ -10,7 +10,14 @@ from pathlib import Path
 from sqlalchemy.engine.url import make_url
 
 from .db import Base, engine
-from .models import Feedback, ChatHistory, ChatbotConfig, Experiment, KnowledgeFile  # noqa: F401
+from .models import (  # noqa: F401
+    ChatHistory,
+    ChatbotConfig,
+    Experiment,
+    Feedback,
+    FeedbackRecommendation,
+    KnowledgeFile,
+)
 from .utils import setup_logging
 
 # Initialize logging

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from .routes_configs import router as configs_router
 from .routes_knowledge import router as knowledge_router
 from .routes_analytics import router as analytics_router
 from .routes_experiments import router as experiments_router
+from .routes_recommendations import router as recommendations_router
 from .demo_seed import seed_demo
 from .init_db import init_database
 
@@ -136,6 +137,7 @@ app.include_router(configs_router, prefix="/api/v1")
 app.include_router(knowledge_router, prefix="/api/v1")
 app.include_router(analytics_router, prefix="/api/v1")
 app.include_router(experiments_router, prefix="/api/v1")
+app.include_router(recommendations_router, prefix="/api/v1")
 
 # Database path logging for debugging
 try:

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -158,6 +158,47 @@ class Experiment(Base):
         return f"<Experiment(id={self.id}, name={self.name}, status={self.status})>"
 
 
+class FeedbackRecommendation(Base):
+    """Human-reviewed prompt improvement derived from negative feedback."""
+
+    __tablename__ = "feedback_recommendations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    theme_key = Column(String(50), nullable=False, index=True)
+    title = Column(String(150), nullable=False)
+    summary = Column(Text, nullable=False)
+    status = Column(
+        String(20),
+        nullable=False,
+        default="pending",
+        index=True,
+        comment="pending, approved, or dismissed",
+    )
+    source_config_id = Column(
+        Integer,
+        ForeignKey("chatbot_config.id"),
+        nullable=True,
+        index=True,
+    )
+    source_feedback_ids = Column(JSON, nullable=False)
+    evidence_examples = Column(JSON, nullable=False)
+    proposed_config_json = Column(JSON, nullable=False)
+    resulting_config_id = Column(
+        Integer,
+        ForeignKey("chatbot_config.id"),
+        nullable=True,
+    )
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    resolved_at = Column(DateTime(timezone=True), nullable=True)
+
+    def __repr__(self) -> str:
+        return (
+            f"<FeedbackRecommendation(id={self.id}, "
+            f"theme={self.theme_key}, status={self.status})>"
+        )
+
+
 class KnowledgeFile(Base):
     """
     Model for storing knowledge file metadata.

--- a/backend/app/recommendations.py
+++ b/backend/app/recommendations.py
@@ -1,0 +1,234 @@
+"""Deterministic negative-feedback clustering and prompt recommendations."""
+
+from collections import defaultdict
+from copy import deepcopy
+import re
+
+from sqlalchemy.orm import Session
+
+from .models import ChatHistory, ChatbotConfig, Feedback
+
+
+THEMES = (
+    {
+        "key": "verbosity",
+        "title": "Make responses more concise",
+        "keywords": (
+            "too long", "verbose", "wordy", "rambling", "shorter",
+            "concise", "too much detail",
+        ),
+        "instruction": (
+            "Keep responses concise and prioritize the direct answer. "
+            "Remove repetition and include only details that materially help the user."
+        ),
+    },
+    {
+        "key": "incomplete",
+        "title": "Cover missing details",
+        "keywords": (
+            "missing", "omitted", "incomplete", "not enough", "lacks",
+            "left out", "didn't include", "did not include",
+        ),
+        "instruction": (
+            "Check that the response addresses every part of the request. "
+            "State assumptions, important tradeoffs, and concrete next steps when relevant."
+        ),
+    },
+    {
+        "key": "accuracy",
+        "title": "Improve factual accuracy",
+        "keywords": (
+            "wrong", "incorrect", "inaccurate", "hallucinated", "made up",
+            "false", "factual error",
+        ),
+        "instruction": (
+            "Prioritize factual accuracy. Do not invent facts; clearly identify uncertainty "
+            "and distinguish verified information from assumptions."
+        ),
+    },
+    {
+        "key": "clarity",
+        "title": "Improve clarity and structure",
+        "keywords": (
+            "unclear", "confusing", "vague", "hard to understand",
+            "poorly explained", "disorganized",
+        ),
+        "instruction": (
+            "Use plain language and a clear structure. Define necessary terms and make the "
+            "reasoning easy to follow without unnecessary jargon."
+        ),
+    },
+    {
+        "key": "relevance",
+        "title": "Stay focused on the request",
+        "keywords": (
+            "irrelevant", "off topic", "off-topic", "didn't answer",
+            "did not answer", "not relevant", "missed the question",
+        ),
+        "instruction": (
+            "Answer the user's actual request before adding context. Avoid tangents and "
+            "explicitly connect each recommendation to the question asked."
+        ),
+    },
+    {
+        "key": "sources",
+        "title": "Strengthen source use",
+        "keywords": (
+            "source", "citation", "evidence", "reference", "unsupported",
+        ),
+        "instruction": (
+            "When using supplied knowledge, cite the relevant source and avoid claims that "
+            "are not supported by the available context."
+        ),
+    },
+    {
+        "key": "tone",
+        "title": "Adjust response tone",
+        "keywords": (
+            "rude", "tone", "unprofessional", "patronizing", "dismissive",
+            "too casual", "too formal",
+        ),
+        "instruction": (
+            "Use a respectful, professional tone calibrated to the user's language and level "
+            "of expertise. Be direct without sounding dismissive."
+        ),
+    },
+    {
+        "key": "latency",
+        "title": "Reduce response latency",
+        "keywords": (
+            "slow", "too long to respond", "latency", "took too long",
+        ),
+        "instruction": (
+            "Prefer an efficient answer structure and avoid unnecessary expansion. Lead with "
+            "the useful result so the response can complete quickly."
+        ),
+    },
+)
+
+OTHER_THEME = {
+    "key": "other",
+    "title": "Review uncategorized failures",
+    "instruction": (
+        "Before answering, verify that the response is accurate, relevant, clear, and complete. "
+        "Address the request directly and avoid unsupported assumptions."
+    ),
+}
+
+
+def classify_feedback(text: str) -> dict:
+    """Assign one primary, explainable theme using transparent keyword rules."""
+    normalized = re.sub(r"\s+", " ", text.lower()).strip()
+    for theme in THEMES:
+        if any(keyword in normalized for keyword in theme["keywords"]):
+            return theme
+    return OTHER_THEME
+
+
+def _prompts_for_responses(
+    db: Session,
+    responses: list[ChatHistory],
+) -> dict[int, str | None]:
+    session_ids = {response.session_id for response in responses if response.session_id}
+    prompts_by_session = defaultdict(list)
+    if session_ids:
+        messages = (
+            db.query(ChatHistory)
+            .filter(
+                ChatHistory.session_id.in_(session_ids),
+                ChatHistory.role == "user",
+            )
+            .order_by(ChatHistory.session_id, ChatHistory.id.desc())
+            .all()
+        )
+        for message in messages:
+            prompts_by_session[message.session_id].append(message)
+
+    return {
+        response.id: next(
+            (
+                message.content
+                for message in prompts_by_session.get(response.session_id, [])
+                if message.id < response.id
+            ),
+            None,
+        )
+        for response in responses
+    }
+
+
+def collect_negative_feedback_clusters(
+    db: Session,
+    limit: int = 200,
+) -> list[dict]:
+    """Cluster recent negative feedback by source configuration and failure theme."""
+    rows = (
+        db.query(Feedback, ChatHistory, ChatbotConfig)
+        .outerjoin(ChatHistory, Feedback.response_id == ChatHistory.id)
+        .outerjoin(ChatbotConfig, Feedback.config_id == ChatbotConfig.id)
+        .filter(Feedback.user_feedback == "thumbs_down")
+        .order_by(Feedback.timestamp.desc())
+        .limit(limit)
+        .all()
+    )
+    prompts = _prompts_for_responses(
+        db,
+        [response for _, response, _ in rows if response is not None],
+    )
+    clusters = {}
+    for feedback, response, config in rows:
+        classification_text = " ".join(
+            value
+            for value in (
+                feedback.comment,
+                prompts.get(response.id) if response else None,
+            )
+            if value
+        )
+        theme = classify_feedback(classification_text)
+        key = (feedback.config_id, theme["key"])
+        cluster = clusters.setdefault(
+            key,
+            {
+                "theme": theme,
+                "config_id": feedback.config_id,
+                "config_name": config.name if config else "Unattributed",
+                "feedback_ids": [],
+                "examples": [],
+            },
+        )
+        cluster["feedback_ids"].append(feedback.id)
+        if len(cluster["examples"]) < 3:
+            cluster["examples"].append(
+                {
+                    "feedback_id": feedback.id,
+                    "prompt": prompts.get(response.id) if response else None,
+                    "response": response.content if response else feedback.message,
+                    "comment": feedback.comment,
+                }
+            )
+    return sorted(
+        clusters.values(),
+        key=lambda cluster: (
+            len(cluster["feedback_ids"]),
+            cluster["theme"]["key"] != "other",
+        ),
+        reverse=True,
+    )
+
+
+def proposed_configuration(
+    source: ChatbotConfig | None,
+    theme: dict,
+) -> dict:
+    """Create a conservative prompt-only proposal from an existing configuration."""
+    baseline = deepcopy(source.config_json) if source else {
+        "system_prompt": "You are a helpful assistant.",
+        "model": "gpt-4o",
+        "temperature": 0.7,
+    }
+    current_prompt = str(baseline.get("system_prompt") or "You are a helpful assistant.").strip()
+    instruction = theme["instruction"]
+    if instruction not in current_prompt:
+        baseline["system_prompt"] = f"{current_prompt}\n\nImprovement instruction: {instruction}"
+    return baseline

--- a/backend/app/routes_recommendations.py
+++ b/backend/app/routes_recommendations.py
@@ -1,0 +1,224 @@
+"""Human-reviewed recommendations generated from recurring negative feedback."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from .auth import verify_bearer_token
+from .db import SessionLocal
+from .models import ChatbotConfig, FeedbackRecommendation
+from .recommendations import collect_negative_feedback_clusters, proposed_configuration
+from .schemas import (
+    FeedbackRecommendationOut,
+    RecommendationApproval,
+    RecommendationStatus,
+)
+
+router = APIRouter(prefix="/recommendations", tags=["flywheel-recommendations"])
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _recommendation_or_404(
+    db: Session,
+    recommendation_id: int,
+) -> FeedbackRecommendation:
+    recommendation = (
+        db.query(FeedbackRecommendation)
+        .filter(FeedbackRecommendation.id == recommendation_id)
+        .first()
+    )
+    if not recommendation:
+        raise HTTPException(status_code=404, detail="Recommendation not found")
+    return recommendation
+
+
+@router.get("", response_model=list[FeedbackRecommendationOut])
+async def list_recommendations(
+    recommendation_status: RecommendationStatus | None = Query(
+        None,
+        alias="status",
+    ),
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    query = db.query(FeedbackRecommendation)
+    if recommendation_status is not None:
+        query = query.filter(
+            FeedbackRecommendation.status == recommendation_status.value
+        )
+    return query.order_by(FeedbackRecommendation.updated_at.desc()).all()
+
+
+@router.post("/generate", response_model=list[FeedbackRecommendationOut])
+async def generate_recommendations(
+    min_count: int = Query(2, ge=1, le=100),
+    limit: int = Query(200, ge=1, le=1000),
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    """Upsert pending recommendations for recurring negative-feedback themes."""
+    clusters = collect_negative_feedback_clusters(db, limit=limit)
+    generated = []
+    try:
+        for cluster in clusters:
+            theme = cluster["theme"]
+            pending = (
+                db.query(FeedbackRecommendation)
+                .filter(
+                    FeedbackRecommendation.source_config_id == cluster["config_id"],
+                    FeedbackRecommendation.theme_key == theme["key"],
+                    FeedbackRecommendation.status == "pending",
+                )
+                .first()
+            )
+            prior = (
+                db.query(FeedbackRecommendation)
+                .filter(
+                    FeedbackRecommendation.source_config_id == cluster["config_id"],
+                    FeedbackRecommendation.theme_key == theme["key"],
+                )
+                .all()
+            )
+            consumed_ids = {
+                feedback_id
+                for recommendation in prior
+                if recommendation.id != (pending.id if pending else None)
+                for feedback_id in recommendation.source_feedback_ids
+            }
+            feedback_ids = (
+                cluster["feedback_ids"]
+                if pending
+                else [
+                    feedback_id
+                    for feedback_id in cluster["feedback_ids"]
+                    if feedback_id not in consumed_ids
+                ]
+            )
+            if len(feedback_ids) < min_count:
+                continue
+            evidence_examples = [
+                example
+                for example in cluster["examples"]
+                if example["feedback_id"] in feedback_ids
+            ]
+            source = (
+                db.query(ChatbotConfig)
+                .filter(ChatbotConfig.id == cluster["config_id"])
+                .first()
+                if cluster["config_id"] is not None
+                else db.query(ChatbotConfig)
+                .filter(ChatbotConfig.is_active.is_(True))
+                .order_by(ChatbotConfig.updated_at.desc())
+                .first()
+            )
+            evidence_count = len(feedback_ids)
+            summary = (
+                f"{evidence_count} negative feedback item(s) for "
+                f"{cluster['config_name']} match the '{theme['title']}' theme."
+            )
+            values = {
+                "title": theme["title"],
+                "summary": summary,
+                "source_feedback_ids": feedback_ids,
+                "evidence_examples": evidence_examples,
+                "proposed_config_json": proposed_configuration(source, theme),
+            }
+            if pending:
+                for field, value in values.items():
+                    setattr(pending, field, value)
+                recommendation = pending
+            else:
+                recommendation = FeedbackRecommendation(
+                    theme_key=theme["key"],
+                    status="pending",
+                    source_config_id=cluster["config_id"],
+                    **values,
+                )
+                db.add(recommendation)
+            generated.append(recommendation)
+        db.commit()
+        for recommendation in generated:
+            db.refresh(recommendation)
+        return generated
+    except SQLAlchemyError:
+        db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to generate recommendations",
+        )
+
+
+@router.post(
+    "/{recommendation_id}/approve",
+    response_model=FeedbackRecommendationOut,
+)
+async def approve_recommendation(
+    recommendation_id: int,
+    request: RecommendationApproval,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    """Create an inactive configuration draft after explicit human approval."""
+    recommendation = _recommendation_or_404(db, recommendation_id)
+    if recommendation.status != "pending":
+        raise HTTPException(status_code=409, detail="Recommendation is not pending")
+    name = request.configuration_name or (
+        f"Draft - {recommendation.title} - {recommendation.id}"
+    )
+    if db.query(ChatbotConfig).filter(ChatbotConfig.name == name).first():
+        raise HTTPException(status_code=400, detail="Configuration name already exists")
+
+    try:
+        draft = ChatbotConfig(
+            name=name,
+            config_json=recommendation.proposed_config_json,
+            is_active=False,
+            tags=[
+                "recommendation-draft",
+                f"theme:{recommendation.theme_key}",
+                f"recommendation:{recommendation.id}",
+            ],
+        )
+        db.add(draft)
+        db.flush()
+        recommendation.status = "approved"
+        recommendation.resulting_config_id = draft.id
+        recommendation.resolved_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(recommendation)
+        return recommendation
+    except SQLAlchemyError:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="Failed to approve recommendation")
+
+
+@router.post(
+    "/{recommendation_id}/dismiss",
+    response_model=FeedbackRecommendationOut,
+)
+async def dismiss_recommendation(
+    recommendation_id: int,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_bearer_token),
+):
+    recommendation = _recommendation_or_404(db, recommendation_id)
+    if recommendation.status != "pending":
+        raise HTTPException(status_code=409, detail="Recommendation is not pending")
+    try:
+        recommendation.status = "dismissed"
+        recommendation.resolved_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(recommendation)
+        return recommendation
+    except SQLAlchemyError:
+        db.rollback()
+        raise HTTPException(status_code=500, detail="Failed to dismiss recommendation")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -167,6 +167,40 @@ class ExperimentOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class RecommendationStatus(str, Enum):
+    """Lifecycle state for a feedback-derived recommendation."""
+
+    pending = "pending"
+    approved = "approved"
+    dismissed = "dismissed"
+
+
+class RecommendationApproval(BaseModel):
+    """Optional configuration name supplied during human approval."""
+
+    configuration_name: Optional[str] = Field(None, min_length=1, max_length=100)
+
+
+class FeedbackRecommendationOut(BaseModel):
+    """Persisted recommendation with evidence and proposed configuration."""
+
+    id: int
+    theme_key: str
+    title: str
+    summary: str
+    status: RecommendationStatus
+    source_config_id: Optional[int]
+    source_feedback_ids: List[int]
+    evidence_examples: List[Dict[str, Any]]
+    proposed_config_json: Dict[str, Any]
+    resulting_config_id: Optional[int]
+    created_at: datetime
+    updated_at: datetime
+    resolved_at: Optional[datetime]
+
+    model_config = {"from_attributes": True}
+
+
 class ChatbotConfigBase(BaseModel):
     """
     Base schema for chatbot configuration.

--- a/backend/tests/test_feedback_recommendations.py
+++ b/backend/tests/test_feedback_recommendations.py
@@ -1,0 +1,151 @@
+"""Integration tests for feedback clustering and human-approved prompt drafts."""
+
+from app.db import SessionLocal
+from app.models import ChatbotConfig
+from app.recommendations import classify_feedback
+
+
+def _negative_feedback(test_client, mock_llm, prompt: str, comment: str):
+    chat = test_client.post(
+        "/api/v1/chat",
+        json={"message": prompt},
+    ).json()
+    response = test_client.post(
+        "/api/v1/feedback",
+        json={
+            "message": chat["reply"],
+            "response_id": chat["assistant_message_id"],
+            "user_feedback": "thumbs_down",
+            "comment": comment,
+        },
+    )
+    assert response.status_code == 201
+    return chat
+
+
+def test_feedback_classifier_uses_explainable_themes():
+    assert classify_feedback("This answer is too long and wordy")["key"] == "verbosity"
+    assert classify_feedback("It omitted the operational risks")["key"] == "incomplete"
+    assert classify_feedback("The factual claim is incorrect")["key"] == "accuracy"
+    assert classify_feedback("I simply disliked it")["key"] == "other"
+
+
+def test_generate_clusters_recurring_negative_feedback(test_client, mock_llm):
+    first = _negative_feedback(
+        test_client,
+        mock_llm,
+        "Summarize the deployment plan",
+        "This was too long and verbose",
+    )
+    _negative_feedback(
+        test_client,
+        mock_llm,
+        "Explain the rollback process",
+        "The answer was wordy; make it shorter",
+    )
+
+    response = test_client.post("/api/v1/recommendations/generate?min_count=2")
+    assert response.status_code == 200
+    recommendations = response.json()
+    assert len(recommendations) == 1
+    recommendation = recommendations[0]
+    assert recommendation["theme_key"] == "verbosity"
+    assert recommendation["status"] == "pending"
+    assert recommendation["source_config_id"] == first["config_id"]
+    assert len(recommendation["source_feedback_ids"]) == 2
+    assert len(recommendation["evidence_examples"]) == 2
+    assert "Keep responses concise" in (
+        recommendation["proposed_config_json"]["system_prompt"]
+    )
+
+
+def test_generation_is_idempotent_for_pending_theme(test_client, mock_llm):
+    for index in range(2):
+        _negative_feedback(
+            test_client,
+            mock_llm,
+            f"Prompt {index}",
+            "This response is unclear and confusing",
+        )
+
+    first = test_client.post("/api/v1/recommendations/generate?min_count=2").json()
+    second = test_client.post("/api/v1/recommendations/generate?min_count=2").json()
+
+    assert len(first) == 1
+    assert len(second) == 1
+    assert first[0]["id"] == second[0]["id"]
+    assert len(test_client.get("/api/v1/recommendations").json()) == 1
+
+
+def test_approval_creates_inactive_configuration_draft(test_client, mock_llm):
+    for index in range(2):
+        _negative_feedback(
+            test_client,
+            mock_llm,
+            f"Accuracy prompt {index}",
+            "This answer is incorrect and contains a factual error",
+        )
+    recommendation = test_client.post(
+        "/api/v1/recommendations/generate?min_count=2"
+    ).json()[0]
+
+    approved = test_client.post(
+        f"/api/v1/recommendations/{recommendation['id']}/approve",
+        json={"configuration_name": "Accuracy improvement draft"},
+    )
+    assert approved.status_code == 200
+    result = approved.json()
+    assert result["status"] == "approved"
+    assert result["resulting_config_id"] > 0
+
+    db = SessionLocal()
+    try:
+        draft = (
+            db.query(ChatbotConfig)
+            .filter(ChatbotConfig.id == result["resulting_config_id"])
+            .one()
+        )
+        assert draft.name == "Accuracy improvement draft"
+        assert draft.is_active is False
+        assert "recommendation-draft" in draft.tags
+        assert "Prioritize factual accuracy" in draft.config_json["system_prompt"]
+    finally:
+        db.close()
+
+    regenerated = test_client.post("/api/v1/recommendations/generate?min_count=2")
+    assert regenerated.status_code == 200
+    assert regenerated.json() == []
+    assert len(test_client.get("/api/v1/recommendations").json()) == 1
+
+
+def test_dismissal_preserves_evidence_without_creating_config(test_client, mock_llm):
+    for index in range(2):
+        _negative_feedback(
+            test_client,
+            mock_llm,
+            f"Relevance prompt {index}",
+            "This was irrelevant and off topic",
+        )
+    recommendation = test_client.post(
+        "/api/v1/recommendations/generate?min_count=2"
+    ).json()[0]
+
+    dismissed = test_client.post(
+        f"/api/v1/recommendations/{recommendation['id']}/dismiss"
+    )
+    assert dismissed.status_code == 200
+    assert dismissed.json()["status"] == "dismissed"
+    assert dismissed.json()["resulting_config_id"] is None
+
+
+def test_single_negative_item_does_not_generate_by_default(test_client, mock_llm):
+    _negative_feedback(
+        test_client,
+        mock_llm,
+        "One-off prompt",
+        "This response is too long",
+    )
+
+    response = test_client.post("/api/v1/recommendations/generate")
+    assert response.status_code == 200
+    assert response.json() == []

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -118,7 +118,9 @@ const elements = {
     variantBConfig: document.getElementById('variantBConfig'),
     variantBWeight: document.getElementById('variantBWeight'),
     createExperimentBtn: document.getElementById('createExperimentBtn'),
-    experimentList: document.getElementById('experimentList')
+    experimentList: document.getElementById('experimentList'),
+    generateRecommendationsBtn: document.getElementById('generateRecommendationsBtn'),
+    recommendationList: document.getElementById('recommendationList')
 };
 
 // Application state
@@ -127,6 +129,7 @@ let currentSessionId = null;
 let activeConfigs = [];
 let experimentDefinitions = [];
 let experimentMetrics = [];
+let feedbackRecommendations = [];
 
 // Utility functions
 function showStatus(message, type = 'success') {
@@ -897,6 +900,95 @@ function renderExperiments() {
     }).join('');
 }
 
+function recommendationInstruction(configJson) {
+    const prompt = String(configJson?.system_prompt || '');
+    const marker = 'Improvement instruction:';
+    const markerIndex = prompt.lastIndexOf(marker);
+    return markerIndex >= 0
+        ? prompt.slice(markerIndex + marker.length).trim()
+        : prompt;
+}
+
+function renderRecommendations() {
+    if (!feedbackRecommendations.length) {
+        elements.recommendationList.innerHTML =
+            '<div class="dashboard-empty">No recurring negative-feedback themes yet. At least two matching negative ratings are required.</div>';
+        return;
+    }
+
+    elements.recommendationList.innerHTML = feedbackRecommendations.map(item => {
+        const examples = item.evidence_examples.map(example => `
+            <div class="evidence-item">
+                <strong>User comment:</strong> ${escapeHtml(example.comment || 'No comment')}<br>
+                <strong>Prompt:</strong> ${escapeHtml(example.prompt || 'Unavailable')}
+            </div>
+        `).join('');
+        const actions = item.status === 'pending'
+            ? `
+                <div class="recommendation-actions">
+                    <button class="btn btn-small" data-recommendation-action="approve" data-recommendation-id="${item.id}">Approve draft</button>
+                    <button class="btn btn-small" data-recommendation-action="dismiss" data-recommendation-id="${item.id}">Dismiss</button>
+                </div>
+            `
+            : item.resulting_config_id
+                ? `<div class="recommendation-actions">Inactive configuration draft #${item.resulting_config_id} created.</div>`
+                : '';
+        return `
+            <article class="recommendation-card ${escapeHtml(item.status)}">
+                <div class="recommendation-header">
+                    <div>
+                        <strong>${escapeHtml(item.title)}</strong>
+                        <div class="recommendation-summary">${escapeHtml(item.summary)}</div>
+                    </div>
+                    <span class="experiment-badge ${item.status === 'approved' ? 'active' : ''}">${escapeHtml(item.status)}</span>
+                </div>
+                <div class="recommendation-instruction">
+                    <strong>Proposed instruction:</strong>
+                    ${escapeHtml(recommendationInstruction(item.proposed_config_json))}
+                </div>
+                <div class="recommendation-evidence">${examples}</div>
+                ${actions}
+            </article>
+        `;
+    }).join('');
+}
+
+async function generateRecommendations() {
+    elements.generateRecommendationsBtn.disabled = true;
+    showAnalyticsStatus('Analyzing recurring negative feedback...');
+    try {
+        await api.post('/recommendations/generate?min_count=2');
+        showAnalyticsStatus('Feedback analysis complete.');
+        await loadAnalytics();
+    } catch (error) {
+        showAnalyticsStatus(`Recommendation error: ${error.message}`, 'error');
+    } finally {
+        elements.generateRecommendationsBtn.disabled = false;
+    }
+}
+
+async function handleRecommendationAction(event) {
+    const button = event.target.closest('[data-recommendation-action]');
+    if (!button) {
+        return;
+    }
+    const recommendationId = button.dataset.recommendationId;
+    const action = button.dataset.recommendationAction;
+    button.disabled = true;
+    try {
+        await api.post(`/recommendations/${recommendationId}/${action}`);
+        showAnalyticsStatus(
+            action === 'approve'
+                ? 'Inactive configuration draft created for human review.'
+                : 'Recommendation dismissed.'
+        );
+        await loadAnalytics();
+    } catch (error) {
+        showAnalyticsStatus(`Recommendation error: ${error.message}`, 'error');
+        button.disabled = false;
+    }
+}
+
 async function createConfiguration(event) {
     event.preventDefault();
     const name = elements.configurationName.value.trim();
@@ -1010,20 +1102,30 @@ async function loadAnalytics() {
     showAnalyticsStatus('Loading analytics...');
 
     try {
-        const [configurations, negativeFeedback, experiments, experimentAnalytics, configs] = await Promise.all([
+        const [
+            configurations,
+            negativeFeedback,
+            experiments,
+            experimentAnalytics,
+            configs,
+            recommendations
+        ] = await Promise.all([
             api.get('/analytics/configurations'),
             api.get('/analytics/negative-feedback?limit=20'),
             api.get('/experiments'),
             api.get('/analytics/experiments'),
-            api.get('/configs?active_only=true&size=100')
+            api.get('/configs?active_only=true&size=100'),
+            api.get('/recommendations')
         ]);
 
         activeConfigs = configs.items;
         experimentDefinitions = experiments;
         experimentMetrics = experimentAnalytics;
+        feedbackRecommendations = recommendations;
         renderSummaryMetrics(configurations);
         renderExperimentConfigOptions(activeConfigs);
         renderExperiments();
+        renderRecommendations();
         renderConfigurationAnalytics(configurations);
         renderNegativeFeedback(negativeFeedback);
         showAnalyticsStatus(`Loaded ${configurations.length} configuration result(s).`);
@@ -1070,6 +1172,8 @@ elements.saveTokenBtn.addEventListener('click', saveAnalyticsToken);
 elements.configurationForm.addEventListener('submit', createConfiguration);
 elements.experimentForm.addEventListener('submit', createExperiment);
 elements.experimentList.addEventListener('click', handleExperimentAction);
+elements.generateRecommendationsBtn.addEventListener('click', generateRecommendations);
+elements.recommendationList.addEventListener('click', handleRecommendationAction);
 
 // Initialize
 console.log('Data Flywheel Chatbot initialized');

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -513,6 +513,70 @@
             color: #166534;
         }
 
+        .recommendation-list {
+            display: grid;
+            gap: 14px;
+            padding: 16px;
+        }
+
+        .recommendation-card {
+            padding: 16px;
+            border: 1px solid #dbe4ef;
+            border-left: 4px solid #7c3aed;
+            border-radius: 8px;
+            background: #fdfcff;
+        }
+
+        .recommendation-card.approved {
+            border-left-color: #198754;
+            background: #fbfffc;
+        }
+
+        .recommendation-card.dismissed {
+            border-left-color: #94a3b8;
+            background: #f8fafc;
+        }
+
+        .recommendation-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            gap: 12px;
+        }
+
+        .recommendation-summary {
+            margin-top: 7px;
+            color: #475569;
+        }
+
+        .recommendation-instruction {
+            margin-top: 12px;
+            padding: 11px 12px;
+            border-radius: 6px;
+            background: #f3e8ff;
+            white-space: pre-wrap;
+        }
+
+        .recommendation-evidence {
+            display: grid;
+            gap: 8px;
+            margin-top: 12px;
+        }
+
+        .evidence-item {
+            padding: 10px 12px;
+            border: 1px solid #e2e8f0;
+            border-radius: 6px;
+            background: white;
+            font-size: 13px;
+        }
+
+        .recommendation-actions {
+            display: flex;
+            gap: 8px;
+            margin-top: 13px;
+        }
+
         .btn-small {
             padding: 6px 9px;
             font-size: 12px;
@@ -808,6 +872,19 @@
                 </form>
                 <div class="experiment-list" id="experimentList">
                     <div class="dashboard-empty">No experiments loaded.</div>
+                </div>
+            </section>
+
+            <section class="dashboard-panel">
+                <div class="panel-header">
+                    <div>
+                        <h2>Feedback improvement recommendations</h2>
+                        <p>Cluster recurring negative feedback and review prompt changes before creating an inactive configuration draft.</p>
+                    </div>
+                    <button class="btn" id="generateRecommendationsBtn">Analyze feedback</button>
+                </div>
+                <div class="recommendation-list" id="recommendationList">
+                    <div class="dashboard-empty">No recommendations loaded.</div>
                 </div>
             </section>
 

--- a/tests/test_frontend_integration.py
+++ b/tests/test_frontend_integration.py
@@ -47,6 +47,8 @@ class TestFrontendIntegration:
         assert 'id="configurationForm"' in response.text
         assert 'id="experimentForm"' in response.text
         assert 'id="experimentList"' in response.text
+        assert 'id="generateRecommendationsBtn"' in response.text
+        assert 'id="recommendationList"' in response.text
 
         script_response = test_client.get("/app.js")
         assert script_response.status_code == 200
@@ -55,6 +57,8 @@ class TestFrontendIntegration:
         assert "createExperiment" in script_response.text
         assert "handleExperimentAction" in script_response.text
         assert "Number.isNaN(temperature)" in script_response.text
+        assert "generateRecommendations" in script_response.text
+        assert "handleRecommendationAction" in script_response.text
 
     # API Accessibility Tests
 


### PR DESCRIPTION
## What changed

- Added deterministic clustering of negative feedback into explainable themes such as verbosity, accuracy, clarity, relevance, completeness, tone, sources, and latency.
- Added persisted recommendations containing source feedback IDs, representative evidence, the source configuration, and a conservative proposed prompt change.
- Added generation deduplication so approved or dismissed evidence is not reused unless enough new matching feedback arrives.
- Added human approval and dismissal endpoints.
- Approval creates an inactive configuration draft tagged with its recommendation and theme.
- Added dashboard controls to analyze feedback, inspect evidence, review proposed instructions, approve drafts, or dismiss recommendations.
- Added integration tests and API documentation.

## Why

The data flywheel could collect feedback and compare configurations, but improvement still required manually reading individual negative comments. This change turns recurring failure signals into reviewable configuration proposals while preserving human control.

## Safety and impact

- Clustering uses transparent keyword rules rather than opaque automated decisions.
- Recommendations do not modify an existing configuration.
- Approval creates an inactive draft only.
- No recommendation can activate an experiment or receive production traffic automatically.
- Evidence and review decisions remain persisted for auditability.

## Validation

- Full Docker suite before the final evidence-deduplication patch: 35 passed, 20 skipped.
- Focused recommendation tests: 6 passed.
- Python compilation, JavaScript syntax, and diff checks passed after the final patch.
- Browser-tested generation, evidence display, approval, inactive draft creation, and responsive mobile layout.
- GitHub Actions will run the complete suite on this PR.
